### PR TITLE
add missing `#include <cassert>`

### DIFF
--- a/include/orc/dwarf_structs.hpp
+++ b/include/orc/dwarf_structs.hpp
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <vector>
 #include <string>
+#include <cassert>
 
 // application
 #include "orc/dwarf_constants.hpp"

--- a/src/string_pool.cpp
+++ b/src/string_pool.cpp
@@ -12,6 +12,7 @@
 #include <mutex>
 #include <unordered_set>
 #include <vector>
+#include <cassert>
 
 // application
 #include "orc/features.hpp"


### PR DESCRIPTION
You do use `assert` macro without including it <cassert>. I fixed it.