### PR TITLE
Function ODRV detection based on the contiguous size of the function code block.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,3 +75,11 @@ add_executable(example_typedef
                ${PROJECT_SOURCE_DIR}/examples/typedef/alt.cpp
 )
 link_via_orc(example_typedef)
+
+##### example app: function
+
+add_executable(example_function
+               ${PROJECT_SOURCE_DIR}/examples/function/main.cpp
+               ${PROJECT_SOURCE_DIR}/examples/function/alt.cpp
+)
+link_via_orc(example_function)

--- a/_orc-config
+++ b/_orc-config
@@ -81,6 +81,7 @@ violation_report = [
     'class:byte_size',
     'member:data_member_location',
     'structure:byte_size',
+    'subprogram:high_pc',
     'subprogram:virtuality',
     'subprogram:vtable_elem_location',
     'typedef:type'

--- a/examples/function/alt.cpp
+++ b/examples/function/alt.cpp
@@ -1,0 +1,20 @@
+// Copyright 2021 Adobe
+// All Rights Reserved.
+//
+// NOTICE: Adobe permits you to use, modify, and distribute this file in accordance with the terms
+// of the Adobe license agreement accompanying it.
+
+#include <iostream>
+
+namespace example_function {
+
+template <class T>
+T foo(T x) {
+    return ((x + x) - 2) * 2 / x;
+}
+
+} // namespace example_function
+
+void alt() {
+    std::cout << "alt: " << example_function::foo<int>(42) << '\n';
+}

--- a/examples/function/main.cpp
+++ b/examples/function/main.cpp
@@ -1,0 +1,24 @@
+// Copyright 2021 Adobe
+// All Rights Reserved.
+//
+// NOTICE: Adobe permits you to use, modify, and distribute this file in accordance with the terms
+// of the Adobe license agreement accompanying it.
+
+#include <iostream>
+
+void alt();
+
+namespace example_function {
+
+template <class T>
+T foo(T x) {
+    return x;
+}
+
+} // namespace example_function
+
+int main() {
+    std::cout << "main: " << example_function::foo<int>(42) << '\n';
+
+    alt();
+}

--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -738,6 +738,9 @@ attribute_value dwarf::implementation::process_form(const attribute& attr,
                 result = evaluate_exprloc(expr_size);
             });
         } break;
+        case dw::form::addr: {
+            result.uint(read64());
+        } break;
         case dw::form::ref_addr: {
             result.reference(read32());
         } break;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -149,7 +149,14 @@ bool nonfatal_attribute(dw::at at) {
             dw::at::decl_file,
             dw::at::decl_line,
             dw::at::frame_base,
-            dw::at::high_pc,
+            // According to section 2.17 of the DWARF spec, if high_pc is a constant (e.g., form
+            // data4) then its value is the size of the function. Likewise, its existence implies
+            // the function it describes is a contiguous block of code in the object file. Since we
+            // assume this attribute is of constant form, this is the size of the function. If two
+            // or more functions with the same name have different high_pc values, their sizes are
+            // different, which means their definitions are going to be different, and that's an
+            // ODRV.
+            // dw::at::high_pc,
             dw::at::location,
             dw::at::low_pc,
             dw::at::name,


### PR DESCRIPTION
This PR extends the tool to compare the sizes of two or more functions with the same name. If their sizes are different, it means their definitions are different, and thus the functions are ODRVs.