### PR TITLE
Change pwd call

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -486,7 +486,7 @@ std::string exec(const char* cmd) {
 /**************************************************************************************************/
 
 void process_orc_config_file(const char* bin_path_string) {
-    std::filesystem::path pwd(exec("pwd"));
+    std::filesystem::path pwd(std::filesystem::current_path());
     std::filesystem::path bin_path(pwd / bin_path_string);
     std::filesystem::path config_path;
 


### PR DESCRIPTION
## Description

The pwd call has a trailing newline which interfered with the
path construction and caused the exists call in the config handling
to fail in the current directory, not finding config files there.

Changed this to a more modern method for getting pwd.

## Related Issue

https://github.com/adobe/orc/issues/9

## How Has This Been Tested?

Tested by putting config file in same directory as binary and then by moving it to the parent directory. Both cases work.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
