### PR TITLE
Issue #4: Better error handling and resolution around libraries/frameworks

### DIFF
--- a/_orc-config
+++ b/_orc-config
@@ -32,13 +32,13 @@ print_symbol_paths = false
 # order of verbosity. The logging level does not affect ODR violation reporting.
 #
 #     'silent': no logging output
-#     'warning': an avoidable issue, but should be addressed
+#     'warning': an avoidable issue that should be addressed
 #     'info': emit brief, informative status
 #     'verbose': copious amounts of information
 #
-# The default value is `'silent'`.
+# The default value is `'warning'`.
 
-log_level = 'silent'
+log_level = 'warning'
 
 # Output a die-count-based progress update throughout the session.
 #


### PR DESCRIPTION
The change will emit a warning about an unfound library or framework instead of throwing a fatal exception. The only side effect here is that some ODRVs that may surface with all libraries and frameworks accounted for may go unreported. Even so, this is better than reporting nothing when you cannot find all libraries/frameworks.

This also changes the default log message level to `warning` instead of `silent`, so missing libraries and frameworks can be called out.