### PR TITLE
A handful of performance improvements

### DIFF
--- a/include/orc/dwarf_constants.hpp
+++ b/include/orc/dwarf_constants.hpp
@@ -15,11 +15,7 @@ namespace dw {
 
 /**************************************************************************************************/
 
-enum class has_children : std::uint8_t { no = 0, yes = 1 };
-
-/**************************************************************************************************/
-
-enum class form : std::uint32_t {
+enum class form : std::uint16_t {
     addr = 0x01,
     block2 = 0x03,
     block4 = 0x04,
@@ -71,7 +67,7 @@ enum class form : std::uint32_t {
 
 /**************************************************************************************************/
 
-enum class at : std::uint32_t {
+enum class at : std::uint16_t {
     none = 0x00,
     sibling = 0x01,
     location = 0x02,
@@ -403,7 +399,7 @@ const char* to_string(at attr);
 
 /**************************************************************************************************/
 
-enum class tag : std::uint32_t {
+enum class tag : std::uint16_t {
     none = 0x0,
     array_type = 0x01,
     class_type = 0x02,

--- a/src/dwarf_structs.cpp
+++ b/src/dwarf_structs.cpp
@@ -78,7 +78,7 @@ std::ostream& operator<<(std::ostream& s, const attribute& x) {
 
 std::ostream& operator<<(std::ostream& s, const die& x) {
     std::string def_loc;
-    auto attributes = x._attributes;
+    std::vector<attribute> attributes(x._attributes, x._attributes + x._attributes_size);
 
     s << "compilation unit: " << x._object_file.allocate_path().filename().string() << ":\n";
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -233,7 +233,7 @@ const die& find_base_type(const dies& dies, const die& d) {
 /**************************************************************************************************/
 
 void resolve_reference_attributes(const dies& dies, die& d) { // REVISIT (fbrereto): d is an out-arg
-    for (auto& attr : d._attributes) {
+    for (auto& attr : d) {
         if (attr._name == dw::at::type) continue;
         if (!attr.has(attribute_value::type::reference)) continue;
         const die& resolved = lookup_die(dies, attr.reference());
@@ -268,10 +268,10 @@ bool type_equivalent(const attribute& x, const attribute& y);
 dw::at find_die_conflict(const die& x, const die& y) {
     if (x._tag != y._tag) return dw::at::orc_tag;
 
-    const auto& yfirst = y._attributes.begin();
-    const auto& ylast = y._attributes.end();
+    const auto& yfirst = y.begin();
+    const auto& ylast = y.end();
 
-    for (const auto& xattr : x._attributes) {
+    for (const auto& xattr : x) {
         auto name = xattr._name;
         if (nonfatal_attribute(name)) continue;
 
@@ -382,7 +382,7 @@ bool skip_die(const dies& dies, die& d, const std::string_view& symbol) {
         resolve_type_attribute(dies, d);
         const auto& type = d.attribute(dw::at::type);
         // if this is a self-referential type, it's die will have no attributes.
-        if (type.die()._attributes.empty()) return true;
+        if (type.die()._attributes_size == 0) return true;
     }
 
     return false;


### PR DESCRIPTION
A couple changes in an effort to improve performance:

- preallocate `attribute`s in 32MB blocks per-thread, and distribute them as necessary. This eliminates the overhead when they were managed by `std::vector`.
- call `shrink_to_fit` on the final die vector. This will shore up any unused capacity in the die vector before being sent off for processing
- order the member fields of `die` such that they will pack better due to C++ alignment rules
- reduce the size of some `enum class` types from 32 to 16 bits, freeing up wasted space

In tests measured via Instruments, I am seeing my test bed go from ~20 sec. processing time to ~12 sec., about a 40% increase in performance.