### PR TITLE
Add switch to show redundant ODRVs

### DIFF
--- a/_orc-config
+++ b/_orc-config
@@ -13,6 +13,13 @@ graceful_exit = false
 
 max_error_count = 0
 
+# When an ODRV is found for a type, ORC will only report the first one if `filter_redundant`  is
+# true. This is generally what you want. Set to false if you wish to see all the conflicts for 
+# a given type, which can be useful when trying to identify a particular violation in code.
+# If `parallel_processing` is true as well, the number of ODRVs reported can vary widely.
+
+filter_redundant = true
+
 # Since ORC is meant to be a drop-in replacement for the ld/libtool, `forward_to_linker` can be used
 # to elide calling the linker, and only perform ORC processing.
 #

--- a/include/orc/settings.hpp
+++ b/include/orc/settings.hpp
@@ -34,6 +34,7 @@ struct settings {
     std::vector<std::string> _violation_ignore;
     bool _parallel_processing{true};
     bool _show_progress{false};
+    bool _filter_redundant{true};
 };
 
 /**************************************************************************************************/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -136,8 +136,8 @@ void report_odrv(const std::string_view& symbol, const die& a, const die& b, dw:
     // A, B, then C -> 1 ODRV, but C, then A, B -> 2 ODRVs. Complicating
     // this is that (as this comment is written) we don't detect supersets.
     // So if C has more methods than A and B it may not be detected.
-    static std::set<std::size_t> unique_odrv_types;
     if (settings._filter_redundant) {
+        static std::set<std::size_t> unique_odrv_types;
         std::size_t symbol_hash = hash_combine(0, symbol, odrv_category);
         bool did_insert = unique_odrv_types.insert(symbol_hash).second;
         if (!did_insert) return; // We have already reported an instance of this.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -137,9 +137,11 @@ void report_odrv(const std::string_view& symbol, const die& a, const die& b, dw:
     // this is that (as this comment is written) we don't detect supersets.
     // So if C has more methods than A and B it may not be detected.
     static std::set<std::size_t> unique_odrv_types;
-    std::size_t symbol_hash = hash_combine(0, symbol, odrv_category);
-    bool did_insert = unique_odrv_types.insert(symbol_hash).second;
-    if (!did_insert) return; // We have already reported an instance of this.
+    if (settings._filter_redundant) {
+        std::size_t symbol_hash = hash_combine(0, symbol, odrv_category);
+        bool did_insert = unique_odrv_types.insert(symbol_hash).second;
+        if (!did_insert) return; // We have already reported an instance of this.
+    }
 
     ostream_safe(odrv_ostream(), [&](auto& s){
         s << problem_prefix() << ": ODRV (" << odrv_category << "); conflict in `"
@@ -544,6 +546,7 @@ void process_orc_config_file(const char* bin_path_string) {
             app_settings._standalone_mode = settings["standalone_mode"].value_or(false);
             app_settings._parallel_processing = settings["parallel_processing"].value_or(true);
             app_settings._show_progress = settings["show_progress"].value_or(false);
+            app_settings._filter_redundant = settings["filter_redundant"].value_or(true);
             app_settings._print_object_file_list =
                 settings["print_object_file_list"].value_or(false);
 


### PR DESCRIPTION
## Description

Generally speaking, seeing redundant ODRVs doesn't help, and can (because of multi-threading) even be a little misleading. But when tracking a particular bug, it can be useful to have a bigger data set.

This simply adds a flag to turn on full reporting, by skipping the uniqueness detection.
