### PR TITLE
Tweaking how linker forwarding is derived to reduce conflicts

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -681,19 +681,22 @@ auto process_command_line(int argc, char** argv) {
         for (std::size_t i{1}; i < argc; ++i) {
             std::string_view arg = argv[i];
             if (arg == "-o") {
+                std::string filename(argv[++i]);
+
                 // next argument is the output file. Use its name to decide
-                // whether we should run in ld or libtool mode.
-                if (std::string(argv[++i]).ends_with(".a")) {
-                    result._libtool_mode = true;
-                    assert(!result._ld_mode);
-                    if (log_level_at_least(settings::log_level::verbose)) {
-                        std::cout << "verbose: mode: libtool\n";
-                    }
-                } else {
-                    result._ld_mode = true;
-                    assert(!result._libtool_mode);
-                    if (log_level_at_least(settings::log_level::verbose)) {
-                        std::cout << "verbose: mode: ld\n";
+                // whether we should run in ld or libtool mode. If the mode
+                // has already been detected, we can skip this step.
+                if (!result._libtool_mode && !result._ld_mode) {
+                    if (filename.ends_with(".a")) {
+                        result._libtool_mode = true;
+                        if (log_level_at_least(settings::log_level::verbose)) {
+                            std::cout << "verbose: mode: libtool\n";
+                        }
+                    } else {
+                        result._ld_mode = true;
+                        if (log_level_at_least(settings::log_level::verbose)) {
+                            std::cout << "verbose: mode: ld\n";
+                        }
                     }
                 }
             } else if (arg == "-Xlinker") {
@@ -710,10 +713,10 @@ auto process_command_line(int argc, char** argv) {
                 }
             } else if (arg == "-target") {
                 result._ld_mode = true;
+                assert(!result._libtool_mode);
                 if (log_level_at_least(settings::log_level::verbose)) {
                     std::cout << "verbose: mode: ld\n";
                 }
-                assert(!result._libtool_mode);
             } else if (arg == "-lc++") {
                 // ignore the C++ standard library
             } else if (arg == "-lSystem") {


### PR DESCRIPTION
When using ORC to build a framework, the tool first correctly derives linker forwarding to `libtool`. However the output name is then parsed, and because it does not end in `.a`, the tool reverts to forwarding to `ld` instead. To correct this, we only attempt to use the filename to derive linker forwarding if it has not already been detected.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
