### PR TITLE
Changes necessary to compile the sources under Ubuntu

### DIFF
--- a/include/orc/features.hpp
+++ b/include/orc/features.hpp
@@ -20,5 +20,6 @@
 // them leak on purpose, cutting our total execution time in half (or better.)
 
 #define ORC_PRIVATE_FEATURE_LEAKY_MEMORY() (1)
+#define ORC_PRIVATE_FEATURE_MACH_O() (defined(__MACH__))
 
 /**************************************************************************************************/

--- a/include/orc/parse_file.hpp
+++ b/include/orc/parse_file.hpp
@@ -7,7 +7,9 @@
 #pragma once
 
 // stdc++
+#include <cstring>
 #include <filesystem>
+#include <functional>
 #include <iostream>
 #include <type_traits>
 
@@ -84,6 +86,12 @@ struct freader {
             } break;
             case std::ios::end: {
                 _p = _f + (size() - offset);
+            } break;
+            default: {
+                // GNU's libstdc++ has an end-of-options marker that the compiler
+                // will complain about as being unhandled here. It should *never*
+                // be used as a valid value for this enumeration.
+                assert(false);
             } break;
         }
     }

--- a/include/orc/settings.hpp
+++ b/include/orc/settings.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstddef>
 #include <string>
 #include <vector>

--- a/src/fat.cpp
+++ b/src/fat.cpp
@@ -7,8 +7,12 @@
 // identity
 #include "orc/fat.hpp"
 
+#include "orc/features.hpp"
+
 // system
+#if ORC_FEATURE(MACH_O)
 #include <mach-o/fat.h>
+#endif // ORC_FEATURE(MACH_O)
 
 /**************************************************************************************************/
 
@@ -17,6 +21,7 @@ void read_fat(const std::string& object_name,
               std::istream::pos_type end_pos,
               file_details details,
               callbacks callbacks) {
+#if ORC_FEATURE(MACH_O)
     auto header = read_pod<fat_header>(s);
     if (details._needs_byteswap) {
         endian_swap(header.magic);
@@ -59,6 +64,7 @@ void read_fat(const std::string& object_name,
             parse_file(object_name, s, s.tellg() + static_cast<std::streamoff>(size), callbacks);
         });
     }
+#endif // ORC_FEATURE(MACH_O)
 }
 
 /**************************************************************************************************/

--- a/src/macho.cpp
+++ b/src/macho.cpp
@@ -7,13 +7,22 @@
 // identity
 #include "orc/macho.hpp"
 
+// application config
+#include "orc/features.hpp"
+
 // system
+#if ORC_FEATURE(MACH_O)
 #include <mach-o/loader.h>
+#endif // ORC_FEATURE(MACH_O)
 
 // application
 #include "orc/dwarf.hpp"
 #include "orc/settings.hpp"
 #include "orc/str.hpp"
+
+/**************************************************************************************************/
+
+#if ORC_FEATURE(MACH_O)
 
 /**************************************************************************************************/
 
@@ -95,11 +104,16 @@ void read_load_command(freader& s, const file_details& details, dwarf& dwarf) {
 
 /**************************************************************************************************/
 
+#endif // ORC_FEATURE(MACH_O)
+
+/**************************************************************************************************/
+
 void read_macho(std::string object_name,
                 freader s,
                 std::istream::pos_type end_pos,
                 file_details details,
                 callbacks callbacks) {
+#if ORC_FEATURE(MACH_O)
     callbacks._do_work([_object_name = std::move(object_name),
                         _s = std::move(s),
                         _details = std::move(details),
@@ -146,6 +160,7 @@ void read_macho(std::string object_name,
 
         dwarf.process();
     });
+#endif // ORC_FEATURE(MACH_O)
 }
 
 /**************************************************************************************************/

--- a/src/parse_file.cpp
+++ b/src/parse_file.cpp
@@ -17,20 +17,20 @@
 // system
 #include <fcntl.h> // open
 #include <sys/mman.h>
-#include <unistd.h> // close#if ORC_FEATURE(MACH_O)
+#include <unistd.h> // close
 
 #if ORC_FEATURE(MACH_O)
 #include <mach-o/fat.h>
 #include <mach-o/loader.h>
 #else
-#define	MH_MAGIC 0xfeedface
-#define MH_CIGAM 0xcefaedfe
-#define MH_MAGIC_64 0xfeedfacf
-#define MH_CIGAM_64 0xcffaedfe
-#define FAT_MAGIC 0xcafebabe
-#define FAT_CIGAM 0xbebafeca
-#define FAT_MAGIC_64 0xcafebabf
-#define FAT_CIGAM_64 0xbfbafeca
+constexpr std::uint32_t MH_MAGIC = 0xfeedface;
+constexpr std::uint32_t MH_CIGAM = 0xcefaedfe;
+constexpr std::uint32_t MH_MAGIC_64 = 0xfeedfacf;
+constexpr std::uint32_t MH_CIGAM_64 = 0xcffaedfe;
+constexpr std::uint32_t FAT_MAGIC = 0xcafebabe;
+constexpr std::uint32_t FAT_CIGAM = 0xbebafeca;
+constexpr std::uint32_t FAT_MAGIC_64 = 0xcafebabf;
+constexpr std::uint32_t FAT_CIGAM_64 = 0xbfbafeca;
 #endif // ORC_FEATURE(MACH_O)
 
 // application

--- a/src/parse_file.cpp
+++ b/src/parse_file.cpp
@@ -7,16 +7,31 @@
 // identity
 #include "orc/parse_file.hpp"
 
+// application config
+#include "orc/features.hpp"
+
 // stdc++
 #include <bit>
 #include <cstdio>
 
 // system
 #include <fcntl.h> // open
+#include <sys/mman.h>
+#include <unistd.h> // close#if ORC_FEATURE(MACH_O)
+
+#if ORC_FEATURE(MACH_O)
 #include <mach-o/fat.h>
 #include <mach-o/loader.h>
-#include <sys/mman.h>
-#include <unistd.h> // close
+#else
+#define	MH_MAGIC 0xfeedface
+#define MH_CIGAM 0xcefaedfe
+#define MH_MAGIC_64 0xfeedfacf
+#define MH_CIGAM_64 0xcffaedfe
+#define FAT_MAGIC 0xcafebabe
+#define FAT_CIGAM 0xbebafeca
+#define FAT_MAGIC_64 0xcafebabf
+#define FAT_CIGAM_64 0xbfbafeca
+#endif // ORC_FEATURE(MACH_O)
 
 // application
 #include "orc/ar.hpp"
@@ -67,6 +82,7 @@ file_details detect_file(freader& s) {
             if (result._needs_byteswap) {
                 endian_swap(cputype);
             }
+#if ORC_FEATURE(MACH_O)
             assert(((cputype & CPU_ARCH_ABI64) != 0) == result._is_64_bit);
             if (cputype == CPU_TYPE_X86) {
                 result._arch = arch::x86;
@@ -81,6 +97,7 @@ file_details detect_file(freader& s) {
             } else {
                 std::cerr << "WARN: Unknown Mach-O cputype\n";
             }
+#endif // ORC_FEATURE(MACH_O)
         }
 
         return result;

--- a/src/string_pool.cpp
+++ b/src/string_pool.cpp
@@ -8,6 +8,7 @@
 #include "orc/string_pool.hpp"
 
 // stdc++
+#include <cstring>
 #include <memory>
 #include <mutex>
 #include <unordered_set>


### PR DESCRIPTION
This technically addresses #18, as the code will now compile under Ubuntu. However, even though this change gets things compiling on non-macOS platforms, the tool is hamstrung. More work will need to be done to add DWARF detection and registration support for the object file format Ubuntu uses.