### PR TITLE
File output support

### DIFF
--- a/_orc-config
+++ b/_orc-config
@@ -3,6 +3,9 @@
 # indicating failure. `graceful_exit` can be useful for older applications that are looking to track
 # and/or reduce their ODR violations over time (versus enforcing zero violations.)
 #
+# Note that in the ORC output, the string "error" will be used if `graceful_exit` is `false`,
+# or "warning" if `grace_exit` is `true`. 
+#
 # The default value is `false`.
 
 graceful_exit = false
@@ -59,6 +62,13 @@ show_progress = false
 # The default value is `false`.
 
 standalone_mode = false
+
+# If defined, ORC will log output to the specified file. (Normal stream output 
+# is unaffected by the `output_file`.) 
+# 
+# The default value is undefined, and no file will be written.
+
+# output_file = "out.txt"
 
 # `print_object_file_list`, when true, will print the list of object files ORC would otherwise
 # process, and then it exits without failure.

--- a/include/orc/settings.hpp
+++ b/include/orc/settings.hpp
@@ -10,6 +10,7 @@
 #include <cstddef>
 #include <string>
 #include <vector>
+#include <fstream>
 
 /**************************************************************************************************/
 
@@ -48,6 +49,7 @@ struct globals {
     std::size_t _die_registered_count{0};
     std::atomic_size_t _die_processed_count{0};
     std::atomic_size_t _die_analyzed_count{0};
+    std::ofstream _fp;
 };
 
 /**************************************************************************************************/


### PR DESCRIPTION
## Description

Allows ORC to write output to the file specified in the configuration file. The output is a duplication of output to the stream.

The normal stream output is unaffected by this setting.

## Motivation and Context

This is useful when ORC is used as part of a build, and it is convenient to have the ORC output as a "sidecar" to the linker output.

## How Has This Been Tested?

Tested in local CI.
