### PR TITLE
Fix crash and errors from code analysis

### DIFF
--- a/include/orc/parse_file.hpp
+++ b/include/orc/parse_file.hpp
@@ -208,6 +208,12 @@ T read_pod(freader& s) {
     return x;
 }
 
+template <>
+inline bool read_pod(freader& s) {
+    char x;
+    s.read(reinterpret_cast<char*>(&x), 1);
+    return x ? true : false;
+}
 /**************************************************************************************************/
 
 std::uint32_t uleb128(freader& s);

--- a/include/orc/settings.hpp
+++ b/include/orc/settings.hpp
@@ -45,8 +45,8 @@ struct globals {
     static globals& instance();
 
     std::atomic_size_t _object_file_count{0};
-    std::size_t _odrv_count{0};
-    std::size_t _die_registered_count{0};
+    std::atomic_size_t _odrv_count{0};
+    std::atomic_size_t _die_registered_count{0};
     std::atomic_size_t _die_processed_count{0};
     std::atomic_size_t _die_analyzed_count{0};
     std::ofstream _fp;

--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -460,7 +460,9 @@ void dwarf::implementation::read_lines() {
 
 const abbrev& dwarf::implementation::find_abbreviation(std::uint32_t code) const {
     auto found = std::lower_bound(_abbreviations.begin(), _abbreviations.end(), code,
-                                  [](const auto& x, const auto& code) { return x._code < code; });
+                                  [](const auto& x, const auto& value) {
+                                        return x._code < value;
+                                  });
     if (found == _abbreviations.end() || found->_code != code) {
         throw std::runtime_error("abbrev not found: " + std::to_string(code));
     }

--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -460,9 +460,7 @@ void dwarf::implementation::read_lines() {
 
 const abbrev& dwarf::implementation::find_abbreviation(std::uint32_t code) const {
     auto found = std::lower_bound(_abbreviations.begin(), _abbreviations.end(), code,
-                                  [](const auto& x, const auto& value) {
-                                        return x._code < value;
-                                  });
+                                  [](const auto& x, const auto& code) { return x._code < code; });
     if (found == _abbreviations.end() || found->_code != code) {
         throw std::runtime_error("abbrev not found: " + std::to_string(code));
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -141,6 +141,9 @@ void report_odrv(const std::string_view& symbol, const die& a, const die& b, dw:
     // So if C has more methods than A and B it may not be detected.
     if (settings._filter_redundant) {
         static std::set<std::size_t> unique_odrv_types;
+        static std::mutex unique_odrv_mutex;
+        
+        std::lock_guard guard(unique_odrv_mutex);        
         std::size_t symbol_hash = hash_combine(0, symbol, odrv_category);
         bool did_insert = unique_odrv_types.insert(symbol_hash).second;
         if (!did_insert) return; // We have already reported an instance of this.

--- a/src/parse_file.cpp
+++ b/src/parse_file.cpp
@@ -115,7 +115,8 @@ std::uint32_t uleb128(freader& s) {
 
     while (true) {
         auto c = s.get();
-        result |= (c & 0x7f) << shift;
+        if (shift < 32) // shifts above 32 on uint32_t are undefined, but the s.get() needs to continue.
+            result |= (c & 0x7f) << shift;
         if (!(c & 0x80)) return result;
         shift += 7;
     }


### PR DESCRIPTION
Fix a (rare) crash. While doing that work, fixed some problems identified by code analysis. 

## Description

The crash (from CI) is very likely because the `std::set` in main.cpp: 

```
static std::set<std::size_t> unique_odrv_types;
```

was being access from multiple threads at the same time. It would only crash if two threads wrote an ODRV report at the same time. It has been elusive to identify and track down. The fix is straightforward; I added a `std::mutex`, which should only be called at relatively low frequency.

I was using ASan, TSan, and UndefidedBehaviorSan, and also identified & fixed:

* `read_pod` not handling `bool` as `true` or `false`
* global counters not being thread safe
* `uleb128`shifting beyond 32 bits

