### PR TITLE
Fix output

### DIFF
--- a/_orc-config
+++ b/_orc-config
@@ -108,7 +108,7 @@ violation_report = [
     'subprogram:vtable_elem_location'
 ]
 
-violation_ignore = [
-    'subprogram:accessibility',
-    'typedef:type',
-]
+# violation_ignore = [
+#     'subprogram:accessibility',
+#     'typedef:type',
+# ]

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -494,7 +494,7 @@ int main(int argc, char** argv) try {
     }
 
     for (const auto& report : orc_process(file_list)) {
-        std::cout << report << '\n';
+        std::cout << report;   // important to NOT add the '\n', because lots of reports are empty, and it creates a lot of blank lines
     }
 
     return epilogue(false);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The ORC output had 2 small bugs:
* The default _orc-config has both a violation_report and violation_ignore. It correctly warns, we just need to comment out the violation_ignore
* The output was generating a blank line for each filtered report, which usually just looked like a huge blank screen. Removed superfluous `\n`

