### PR TITLE
Adding Job Summary to Build and Test GitHub Action

### DIFF
--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -11,3 +11,5 @@ if __name__ == "__main__":
     f.write("| Run | Result | Notes |")
     f.write("|---|---|---|")
     f.write("| Hello | world! | :rocket: |")
+
+    f.write(sys.argv[2])

--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -5,11 +5,13 @@ if __name__ == "__main__":
     for i, arg in enumerate(sys.argv):
         print(f"Argument {i:>6}: {arg}")
 
+    original_stdout = sys.stdout
+
     f = open(sys.argv[1], "w")
 
-    f.write("# Job Summary")
-    f.write("| Run | Result | Notes |")
-    f.write("|---|---|---|")
-    f.write("| Hello | world! | :rocket: |")
+    sys.stdout = f
 
-    f.write(sys.argv[2])
+    print("# Job Summary")
+    print("| Run | Result | Notes |")
+    print("|---|---|---|")
+    print("| Hello | world! | :rocket: |")

--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -1,4 +1,5 @@
 import sys
+import json
 
 if __name__ == "__main__":
     print(f"Arguments count: {len(sys.argv)}")

--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -8,17 +8,17 @@ if __name__ == "__main__":
 
     sys.stdout = open(sys.argv[1], "w")
 
-    github = json.load(sys.argv[2])
-    # job = json.load(sys.argv[3])
-    # steps = json.load(sys.argv[4])
-    # runner = json.load(sys.argv[5])
-    # strategy = json.load(sys.argv[6])
-    # matrix = json.load(sys.argv[7])
+    github = json.load(open(sys.argv[2], "r"))
+    job = json.load(open(sys.argv[3], "r"))
+    steps = json.load(open(sys.argv[4], "r"))
+    runner = json.load(open(sys.argv[5], "r"))
+    strategy = json.load(open(sys.argv[6], "r"))
+    matrix = json.load(open(sys.argv[7], "r"))
 
     print("# Job Summary")
     print("| Run | Result | Notes |")
     print("|---|---|---|")
 
-    # for key in steps:
-    #     value = steps[key];
-    #     print(f"| {key} | {value.outcome} | :rocket: |")
+    for key in steps:
+        value = steps[key];
+        print(f"| {key} | {value.outcome} | :rocket: |")

--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -15,6 +15,24 @@ if __name__ == "__main__":
     strategy = json.load(open(sys.argv[6], "r"))
     matrix = json.load(open(sys.argv[7], "r"))
 
+    print("# github dump")
+    print(f"{github}")
+
+    print("# job dump")
+    print(f"{job}")
+
+    print("# steps dump")
+    print(f"{steps}")
+
+    print("# runner dump")
+    print(f"{runner}")
+
+    print("# strategy dump")
+    print(f"{strategy}")
+
+    print("# matrix dump")
+    print(f"{matrix}")
+
     print("# Job Summary")
     print("| Run | Result | Notes |")
     print("|---|---|---|")
@@ -22,5 +40,5 @@ if __name__ == "__main__":
     for key in steps:
         value = steps[key];
         outcome = value['outcome']
-        outcome_emoji = outcome == 'success' ? ":green_circle:" : ":red_circle:"
+        outcome_emoji = ":green_circle:" if outcome == 'success' else ":red_circle:"
         print(f"| {key} | {outcome_emoji} {outcome} | :rocket: |")

--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -21,4 +21,6 @@ if __name__ == "__main__":
 
     for key in steps:
         value = steps[key];
-        print(f"| {key} | {value} | :rocket: |")
+        outcome = value['outcome']
+        outcome_emoji = outcome == 'success' ? ":green_circle:" : ":red_circle:"
+        print(f"| {key} | {outcome_emoji} {outcome} | :rocket: |")

--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -6,13 +6,19 @@ if __name__ == "__main__":
     for i, arg in enumerate(sys.argv):
         print(f"Argument {i:>6}: {arg}")
 
-    original_stdout = sys.stdout
+    sys.stdout = open(sys.argv[1], "w")
 
-    f = open(sys.argv[1], "w")
-
-    sys.stdout = f
+    github = json.load(sys.argv[2])
+    job = json.load(sys.argv[3])
+    steps = json.load(sys.argv[4])
+    runner = json.load(sys.argv[5])
+    strategy = json.load(sys.argv[6])
+    matrix = json.load(sys.argv[7])
 
     print("# Job Summary")
     print("| Run | Result | Notes |")
     print("|---|---|---|")
-    print("| Hello | world! | :rocket: |")
+
+    for key in steps:
+        value = steps[key];
+        print(f"| {key} | {value.outcome} | :rocket: |")

--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -1,0 +1,13 @@
+import sys
+
+if __name__ == "__main__":
+    print(f"Arguments count: {len(sys.argv)}")
+    for i, arg in enumerate(sys.argv):
+        print(f"Argument {i:>6}: {arg}")
+
+    f = open(sys.argv[1], "w")
+
+    f.write("# Job Summary")
+    f.write("| Run | Result | Notes |")
+    f.write("|---|---|---|")
+    f.write("| Hello | world! | :rocket: |")

--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -21,4 +21,4 @@ if __name__ == "__main__":
 
     for key in steps:
         value = steps[key];
-        print(f"| {key} | {value.outcome} | :rocket: |")
+        print(f"| {key} | {value} | :rocket: |")

--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -9,16 +9,16 @@ if __name__ == "__main__":
     sys.stdout = open(sys.argv[1], "w")
 
     github = json.load(sys.argv[2])
-    job = json.load(sys.argv[3])
-    steps = json.load(sys.argv[4])
-    runner = json.load(sys.argv[5])
-    strategy = json.load(sys.argv[6])
-    matrix = json.load(sys.argv[7])
+    # job = json.load(sys.argv[3])
+    # steps = json.load(sys.argv[4])
+    # runner = json.load(sys.argv[5])
+    # strategy = json.load(sys.argv[6])
+    # matrix = json.load(sys.argv[7])
 
     print("# Job Summary")
     print("| Run | Result | Notes |")
     print("|---|---|---|")
 
-    for key in steps:
-        value = steps[key];
-        print(f"| {key} | {value.outcome} | :rocket: |")
+    # for key in steps:
+    #     value = steps[key];
+    #     print(f"| {key} | {value.outcome} | :rocket: |")

--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -4,18 +4,17 @@ import json
 if __name__ == "__main__":
     sys.stdout = open(sys.argv[1], "w")
     github = json.load(open(sys.argv[2], "r"))
-    job = json.load(open(sys.argv[3], "r"))
-    steps = json.load(open(sys.argv[4], "r"))
-    runner = json.load(open(sys.argv[5], "r"))
-    strategy = json.load(open(sys.argv[6], "r"))
-    matrix = json.load(open(sys.argv[7], "r"))
+    steps = json.load(open(sys.argv[3], "r"))
 
-    print(f"# {github['workflow']} Summary")
+    print(f"# {github['workflow']}: Job Summary")
     print("")
+
 
     print("## Details")
     print(f"- started by: `{github['actor']}`")
-    print(f"- branch: `{github['ref']}`")
+    if (github['event']['pull_request']):
+        print(f"- branch: `{github['event']['pull_request']['head']['ref']}`")
+    print(f"- action: `{github['event']['action']}`")
 
     print("")
 
@@ -27,4 +26,5 @@ if __name__ == "__main__":
         value = steps[key];
         outcome = value['outcome']
         outcome_emoji = ":green_circle:" if outcome == 'success' else ":red_circle:"
-        print(f"| {key} | {outcome_emoji} {outcome} | :rocket: |")
+        outputs = value['outputs']
+        print(f"| {key} | {outcome_emoji} {outcome} | {outputs} |")

--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -2,12 +2,7 @@ import sys
 import json
 
 if __name__ == "__main__":
-    print(f"Arguments count: {len(sys.argv)}")
-    for i, arg in enumerate(sys.argv):
-        print(f"Argument {i:>6}: {arg}")
-
     sys.stdout = open(sys.argv[1], "w")
-
     github = json.load(open(sys.argv[2], "r"))
     job = json.load(open(sys.argv[3], "r"))
     steps = json.load(open(sys.argv[4], "r"))
@@ -15,25 +10,16 @@ if __name__ == "__main__":
     strategy = json.load(open(sys.argv[6], "r"))
     matrix = json.load(open(sys.argv[7], "r"))
 
-    print("# github dump")
-    print(f"{github}")
+    print(f"# {github['workflow']} Summary")
+    print("")
 
-    print("# job dump")
-    print(f"{job}")
+    print("## Details")
+    print(f"- started by: `{github['actor']}`")
+    print(f"- branch: `{github['ref']}`")
 
-    print("# steps dump")
-    print(f"{steps}")
+    print("")
 
-    print("# runner dump")
-    print(f"{runner}")
-
-    print("# strategy dump")
-    print(f"{strategy}")
-
-    print("# matrix dump")
-    print(f"{matrix}")
-
-    print("# Job Summary")
+    print("## Summary of Steps")
     print("| Run | Result | Notes |")
     print("|---|---|---|")
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,13 +51,13 @@ jobs:
       - name: 🏃 orc_test w/ UBSan
         run: |
           # ./build/Release/orc_test ./test/battery
+      - name: ✏️ github json
+        uses: jsdaniell/create-json@1.1.2
+        with:
+          name: "github.json"
+          json: ${{ toJSON(github) }}
       - name: ✍️ job summary
         run: |
-          GITHUB_JSON=${{ toJSON(github) }}
-          GITHUB_JSON="${GITHUB_JSON//'%'/'%25'}"
-          GITHUB_JSON="${GITHUB_JSON//$'\n'/'%0A'}"
-          GITHUB_JSON="${GITHUB_JSON//$'\r'/'%0D'}"
-          echo '$GITHUB_JSON' > github.json
           echo '${{ toJSON(job) }}' > job.json
           echo '${{ toJSON(steps) }}' > steps.json
           echo '${{ toJSON(runner) }}' > runner.json

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -59,17 +59,23 @@ jobs:
         run: |
           # ./build/Release/orc_test ./test/battery
       - name: Dump GitHub context
-        run: # echo '${{ toJSON(github) }}'
+        run: |
+          # echo '${{ toJSON(github) }}'
       - name: Dump job context
-        run: # echo '${{ toJSON(job) }}'
+        run: |
+          # echo '${{ toJSON(job) }}'
       - name: Dump steps context
-        run: # echo '${{ toJSON(steps) }}'
+        run: |
+          # echo '${{ toJSON(steps) }}'
       - name: Dump runner context
-        run: # echo '${{ toJSON(runner) }}'
+        run: |
+          # echo '${{ toJSON(runner) }}'
       - name: Dump strategy context
-        run: # echo '${{ toJSON(strategy) }}'
+        run: |
+          # echo '${{ toJSON(strategy) }}'
       - name: Dump matrix context
-        run: # echo '${{ toJSON(matrix) }}'
+        run: |
+          # echo '${{ toJSON(matrix) }}'
       - name: ✍️ job summary
         run: |
           python generate_job_summary.py $GITHUB_STEP_SUMMARY ${{ toJSON(steps) }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -59,18 +59,17 @@ jobs:
         run: |
           # ./build/Release/orc_test ./test/battery
       - name: Dump GitHub context
-        id: github_context_step
-        run: echo '${{ toJSON(github) }}'
+        run: # echo '${{ toJSON(github) }}'
       - name: Dump job context
-        run: echo '${{ toJSON(job) }}'
+        run: # echo '${{ toJSON(job) }}'
       - name: Dump steps context
-        run: echo '${{ toJSON(steps) }}'
+        run: # echo '${{ toJSON(steps) }}'
       - name: Dump runner context
-        run: echo '${{ toJSON(runner) }}'
+        run: # echo '${{ toJSON(runner) }}'
       - name: Dump strategy context
-        run: echo '${{ toJSON(strategy) }}'
+        run: # echo '${{ toJSON(strategy) }}'
       - name: Dump matrix context
-        run: echo '${{ toJSON(matrix) }}'
+        run: # echo '${{ toJSON(matrix) }}'
       - name: ✍️ job summary
         run: |
           python generate_job_summary.py $GITHUB_STEP_SUMMARY ${{ toJSON(steps) }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -61,31 +61,11 @@ jobs:
         with:
           name: "github.json"
           json: ${{ toJSON(github) }}
-      - name: ✏️ job json
-        uses: jsdaniell/create-json@1.1.2
-        with:
-          name: "job.json"
-          json: ${{ toJSON(job) }}
       - name: ✏️ steps json
         uses: jsdaniell/create-json@1.1.2
         with:
           name: "steps.json"
           json: ${{ toJSON(steps) }}
-      - name: ✏️ runner json
-        uses: jsdaniell/create-json@1.1.2
-        with:
-          name: "runner.json"
-          json: ${{ toJSON(runner) }}
-      - name: ✏️ strategy json
-        uses: jsdaniell/create-json@1.1.2
-        with:
-          name: "strategy.json"
-          json: ${{ toJSON(strategy) }}
-      - name: ✏️ matrix json
-        uses: jsdaniell/create-json@1.1.2
-        with:
-          name: "matrix.json"
-          json: ${{ toJSON(matrix) }}
       - name: ✍️ job summary
         run: |
-          python ${GITHUB_WORKSPACE}/.github/generate_job_summary.py $GITHUB_STEP_SUMMARY github.json job.json steps.json runner.json strategy.json matrix.json
+          python ${GITHUB_WORKSPACE}/.github/generate_job_summary.py $GITHUB_STEP_SUMMARY github.json steps.json

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -56,11 +56,31 @@ jobs:
         with:
           name: "github.json"
           json: ${{ toJSON(github) }}
+      - name: ✏️ job json
+        uses: jsdaniell/create-json@1.1.2
+        with:
+          name: "job.json"
+          json: ${{ toJSON(job) }}
+      - name: ✏️ steps json
+        uses: jsdaniell/create-json@1.1.2
+        with:
+          name: "steps.json"
+          json: ${{ toJSON(steps) }}
+      - name: ✏️ runner json
+        uses: jsdaniell/create-json@1.1.2
+        with:
+          name: "runner.json"
+          json: ${{ toJSON(runner) }}
+      - name: ✏️ strategy json
+        uses: jsdaniell/create-json@1.1.2
+        with:
+          name: "strategy.json"
+          json: ${{ toJSON(strategy) }}
+      - name: ✏️ matrix json
+        uses: jsdaniell/create-json@1.1.2
+        with:
+          name: "matrix.json"
+          json: ${{ toJSON(matrix) }}
       - name: ✍️ job summary
         run: |
-          echo '${{ toJSON(job) }}' > job.json
-          echo '${{ toJSON(steps) }}' > steps.json
-          echo '${{ toJSON(runner) }}' > runner.json
-          echo '${{ toJSON(strategy) }}' > strategy.json
-          echo '${{ toJSON(matrix) }}' > matrix.json
           python ${GITHUB_WORKSPACE}/.github/generate_job_summary.py $GITHUB_STEP_SUMMARY github.json job.json steps.json runner.json strategy.json matrix.json

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -47,32 +47,32 @@ jobs:
         id: build-orc_test-asan
         continue-on-error: true
         run: |
-          # xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableAddressSanitizer YES -hideShellScriptEnvironment
+          xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableAddressSanitizer YES -hideShellScriptEnvironment
       - name: 🏃 orc_test w/ ASan
         id: run-orc_test-asan
         continue-on-error: true
         run: |
-          # ./build/Release/orc_test ./test/battery
+          ./build/Release/orc_test ./test/battery
       - name: 🛠️ orc_test w/ TSan
         id: build-orc_test-tsan
         continue-on-error: true
         run: |
-          # xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableThreadSanitizer YES -hideShellScriptEnvironment
+          xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableThreadSanitizer YES -hideShellScriptEnvironment
       - name: 🏃 orc_test w/ TSan
         id: run-orc_test-tsan
         continue-on-error: true
         run: |
-          # ./build/Release/orc_test ./test/battery
+          ./build/Release/orc_test ./test/battery
       - name: 🛠️ orc_test w/ UBSan
         id: build-orc_test-ubsan
         continue-on-error: true
         run: |
-          # xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableUndefinedBehaviorSanitizer YES -hideShellScriptEnvironment
+          xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableUndefinedBehaviorSanitizer YES -hideShellScriptEnvironment
       - name: 🏃 orc_test w/ UBSan
         id: run-orc_test-ubsan
         continue-on-error: true
         run: |
-          # ./build/Release/orc_test ./test/battery
+          ./build/Release/orc_test ./test/battery
       - name: ✏️ github json
         uses: jsdaniell/create-json@1.1.2
         continue-on-error: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -58,24 +58,6 @@ jobs:
       - name: 🏃 orc_test w/ UBSan
         run: |
           # ./build/Release/orc_test ./test/battery
-      - name: Dump GitHub context
-        run: |
-          # echo '${{ toJSON(github) }}'
-      - name: Dump job context
-        run: |
-          # echo '${{ toJSON(job) }}'
-      - name: Dump steps context
-        run: |
-          # echo '${{ toJSON(steps) }}'
-      - name: Dump runner context
-        run: |
-          # echo '${{ toJSON(runner) }}'
-      - name: Dump strategy context
-        run: |
-          # echo '${{ toJSON(strategy) }}'
-      - name: Dump matrix context
-        run: |
-          # echo '${{ toJSON(matrix) }}'
       - name: ✍️ job summary
         run: |
           python generate_job_summary.py $GITHUB_STEP_SUMMARY ${{ toJSON(steps) }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -53,7 +53,11 @@ jobs:
           # ./build/Release/orc_test ./test/battery
       - name: ✍️ job summary
         run: |
-          echo '${{ toJSON(github) }}' > github.json
+          GITHUB_JSON=${{ toJSON(github) }}
+          GITHUB_JSON="${GITHUB_JSON//'%'/'%25'}"
+          GITHUB_JSON="${GITHUB_JSON//$'\n'/'%0A'}"
+          GITHUB_JSON="${GITHUB_JSON//$'\r'/'%0D'}"
+          echo '$GITHUB_JSON' > github.json
           echo '${{ toJSON(job) }}' > job.json
           echo '${{ toJSON(steps) }}' > steps.json
           echo '${{ toJSON(runner) }}' > runner.json

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,6 +9,10 @@ jobs:
   build-and-test:
     runs-on: macos-latest
     steps:
+      - name: 🐍 setup
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
       - name: ✍️ job summary
         run: |
           echo '# Job Summary' >> $GITHUB_STEP_SUMMARY
@@ -56,38 +60,17 @@ jobs:
           # ./build/Release/orc_test ./test/battery
       - name: Dump GitHub context
         id: github_context_step
-        run: |
-          echo '# GitHub context' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo '${{ toJSON(github) }}' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+        run: echo '${{ toJSON(github) }}'
       - name: Dump job context
-        run: |
-          echo '# job context' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo '${{ toJSON(job) }}' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+        run: echo '${{ toJSON(job) }}'
       - name: Dump steps context
-        run: |
-          echo '# steps context' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo '${{ toJSON(steps) }}' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+        run: echo '${{ toJSON(steps) }}'
       - name: Dump runner context
-        run: |
-          echo '# runner context' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo '${{ toJSON(runner) }}' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+        run: echo '${{ toJSON(runner) }}'
       - name: Dump strategy context
-        run: |
-          echo '# strategy context' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo '${{ toJSON(strategy) }}' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+        run: echo '${{ toJSON(strategy) }}'
       - name: Dump matrix context
+        run: echo '${{ toJSON(matrix) }}'
+      - name: ✍️ job summary
         run: |
-          echo '# matrix context' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo '${{ toJSON(matrix) }}' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+          python generate_job_summary.py $GITHUB_STEP_SUMMARY ${{ toJSON(steps) }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DORC_BUILD_EXAMPLES=0 -GXcode ..
+          # cmake -DORC_BUILD_EXAMPLES=0 -GXcode ..
       - name: 🛠️ orc debug
         run: |
           # xcodebuild -project ./build/orc.xcodeproj -scheme orc_orc -configuration Debug -hideShellScriptEnvironment
@@ -53,10 +53,10 @@ jobs:
           # ./build/Release/orc_test ./test/battery
       - name: ✍️ job summary
         run: |
-          echo "${{ toJSON(github) }}" > github.json
-          echo "${{ toJSON(job) }}" > job.json
-          echo "${{ toJSON(steps) }}" > steps.json
-          echo "${{ toJSON(runner) }}" > runner.json
-          echo "${{ toJSON(strategy) }}" > strategy.json
-          echo "${{ toJSON(matrix) }}" > matrix.json
+          echo '${{ toJSON(github) }}' > github.json
+          echo '${{ toJSON(job) }}' > job.json
+          echo '${{ toJSON(steps) }}' > steps.json
+          echo '${{ toJSON(runner) }}' > runner.json
+          echo '${{ toJSON(strategy) }}' > strategy.json
+          echo '${{ toJSON(matrix) }}' > matrix.json
           python ${GITHUB_WORKSPACE}/.github/generate_job_summary.py $GITHUB_STEP_SUMMARY github.json job.json steps.json runner.json strategy.json matrix.json

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   build-and-test:
     runs-on: macos-latest
-    continue-on-error: true
     steps:
       - name: 🐍 setup
         uses: actions/setup-python@v2
@@ -19,60 +18,74 @@ jobs:
         uses: actions/checkout@v3
       - name: 🏗️ project files
         id: setup-project-files
+        continue-on-error: true
         run: |
           mkdir build
           cd build
           cmake -DORC_BUILD_EXAMPLES=0 -GXcode ..
       - name: 🛠️ orc debug
         id: build-orc-debug
+        continue-on-error: true
         run: |
           xcodebuild -project ./build/orc.xcodeproj -scheme orc_orc -configuration Debug -hideShellScriptEnvironment
       - name: 🛠️ orc release
         id: build-orc-release
+        continue-on-error: true
         run: |
           xcodebuild -project ./build/orc.xcodeproj -scheme orc_orc -configuration Release -hideShellScriptEnvironment
       - name: 🛠️ orc_test
         id: build-orc_test
+        continue-on-error: true
         run: |
           xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -hideShellScriptEnvironment
       - name: 🏃 orc_test
         id: run-orc_test
+        continue-on-error: true
         run: |
           /usr/bin/time -l ./build/Release/orc_test ./test/battery
       - name: 🛠️ orc_test w/ ASan
         id: build-orc_test-asan
+        continue-on-error: true
         run: |
           # xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableAddressSanitizer YES -hideShellScriptEnvironment
       - name: 🏃 orc_test w/ ASan
         id: run-orc_test-asan
+        continue-on-error: true
         run: |
           # ./build/Release/orc_test ./test/battery
       - name: 🛠️ orc_test w/ TSan
         id: build-orc_test-tsan
+        continue-on-error: true
         run: |
           # xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableThreadSanitizer YES -hideShellScriptEnvironment
       - name: 🏃 orc_test w/ TSan
         id: run-orc_test-tsan
+        continue-on-error: true
         run: |
           # ./build/Release/orc_test ./test/battery
       - name: 🛠️ orc_test w/ UBSan
         id: build-orc_test-ubsan
+        continue-on-error: true
         run: |
           # xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableUndefinedBehaviorSanitizer YES -hideShellScriptEnvironment
       - name: 🏃 orc_test w/ UBSan
         id: run-orc_test-ubsan
+        continue-on-error: true
         run: |
           # ./build/Release/orc_test ./test/battery
       - name: ✏️ github json
         uses: jsdaniell/create-json@1.1.2
+        continue-on-error: true
         with:
           name: "github.json"
           json: ${{ toJSON(github) }}
       - name: ✏️ steps json
         uses: jsdaniell/create-json@1.1.2
+        continue-on-error: true
         with:
           name: "steps.json"
           json: ${{ toJSON(steps) }}
       - name: ✍️ job summary
+        continue-on-error: true
         run: |
           python ${GITHUB_WORKSPACE}/.github/generate_job_summary.py $GITHUB_STEP_SUMMARY github.json steps.json

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -53,4 +53,4 @@ jobs:
           # ./build/Release/orc_test ./test/battery
       - name: ✍️ job summary
         run: |
-          python ${GITHUB_WORKSPACE}/.github/generate_job_summary.py $GITHUB_STEP_SUMMARY ${{ steps }}
+          python ${GITHUB_WORKSPACE}/.github/generate_job_summary.py $GITHUB_STEP_SUMMARY '${{ toJSON(steps) }}'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -54,3 +54,40 @@ jobs:
       - name: 🏃 orc_test w/ UBSan
         run: |
           # ./build/Release/orc_test ./test/battery
+      - name: Dump GitHub context
+        id: github_context_step
+        run: |
+          echo '# GitHub context' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo '${{ toJSON(github) }}' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+      - name: Dump job context
+        run: |
+          echo '# job context' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo '${{ toJSON(job) }}' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+      - name: Dump steps context
+        run: |
+          echo '# steps context' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo '${{ toJSON(steps) }}' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+      - name: Dump runner context
+        run: |
+          echo '# runner context' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo '${{ toJSON(runner) }}' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+      - name: Dump strategy context
+        run: |
+          echo '# strategy context' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo '${{ toJSON(strategy) }}' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+      - name: Dump matrix context
+        run: |
+          echo '# matrix context' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo '${{ toJSON(matrix) }}' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,8 +9,15 @@ jobs:
   build-and-test:
     runs-on: macos-latest
     steps:
+      - name: Updating Action Summary
+        run: echo '# Job Summary' >> $GITHUB_STEP_SUMMARY
+        run: echo '| Run | Result | Notes |' >> $GITHUB_STEP_SUMMARY
+        run: echo '|---|---|---|' >> $GITHUB_STEP_SUMMARY
       - name: ⬇️ sources
+        id: checkout
         uses: actions/checkout@v3
+      - name: Updating Action Summary
+        run: echo '| Checkout | ${{ steps.checkout.outcome }} | |' >> $GITHUB_STEP_SUMMARY
       - name: 🏗️ project files
         run: |
           mkdir build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,7 @@ jobs:
   build-and-test:
     runs-on: macos-latest
     steps:
-      - name: Updating Action Summary
+      - name: ✍️ job summary
         run: |
           echo '# Job Summary' >> $GITHUB_STEP_SUMMARY
           echo '| Run | Result | Notes |' >> $GITHUB_STEP_SUMMARY
@@ -17,7 +17,7 @@ jobs:
       - name: ⬇️ sources
         id: checkout
         uses: actions/checkout@v3
-      - name: Updating Action Summary
+      - name: ✍️ job summary
         run: echo '| Checkout | ${{ steps.checkout.outcome }} | |' >> $GITHUB_STEP_SUMMARY
       - name: 🏗️ project files
         run: |
@@ -26,31 +26,31 @@ jobs:
           cmake -DORC_BUILD_EXAMPLES=0 -GXcode ..
       - name: 🛠️ orc debug
         run: |
-          xcodebuild -project ./build/orc.xcodeproj -scheme orc_orc -configuration Debug -hideShellScriptEnvironment
+          # xcodebuild -project ./build/orc.xcodeproj -scheme orc_orc -configuration Debug -hideShellScriptEnvironment
       - name: 🛠️ orc release
         run: |
-          xcodebuild -project ./build/orc.xcodeproj -scheme orc_orc -configuration Release -hideShellScriptEnvironment
+          # xcodebuild -project ./build/orc.xcodeproj -scheme orc_orc -configuration Release -hideShellScriptEnvironment
       - name: 🛠️ orc_test
         run: |
-          xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -hideShellScriptEnvironment
+          # xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -hideShellScriptEnvironment
       - name: 🏃 orc_test
         run: |
-          /usr/bin/time -l ./build/Release/orc_test ./test/battery
+          # /usr/bin/time -l ./build/Release/orc_test ./test/battery
       - name: 🛠️ orc_test w/ ASan
         run: |
-          xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableAddressSanitizer YES -hideShellScriptEnvironment
+          # xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableAddressSanitizer YES -hideShellScriptEnvironment
       - name: 🏃 orc_test w/ ASan
         run: |
-          ./build/Release/orc_test ./test/battery
+          # ./build/Release/orc_test ./test/battery
       - name: 🛠️ orc_test w/ TSan
         run: |
-          xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableThreadSanitizer YES -hideShellScriptEnvironment
+          # xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableThreadSanitizer YES -hideShellScriptEnvironment
       - name: 🏃 orc_test w/ TSan
         run: |
-          ./build/Release/orc_test ./test/battery
+          # ./build/Release/orc_test ./test/battery
       - name: 🛠️ orc_test w/ UBSan
         run: |
-          xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableUndefinedBehaviorSanitizer YES -hideShellScriptEnvironment
+          # xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableUndefinedBehaviorSanitizer YES -hideShellScriptEnvironment
       - name: 🏃 orc_test w/ UBSan
         run: |
-          ./build/Release/orc_test ./test/battery
+          # ./build/Release/orc_test ./test/battery

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,23 +14,28 @@ jobs:
         with:
           python-version: 3.8
       - name: ⬇️ sources
-        id: checkout
+        id: download-sources
         uses: actions/checkout@v3
       - name: 🏗️ project files
+        id: setup-project-files
         run: |
           mkdir build
           cd build
           # cmake -DORC_BUILD_EXAMPLES=0 -GXcode ..
       - name: 🛠️ orc debug
+        id: build-orc-debug
         run: |
           # xcodebuild -project ./build/orc.xcodeproj -scheme orc_orc -configuration Debug -hideShellScriptEnvironment
       - name: 🛠️ orc release
+        id: build-orc-release
         run: |
           # xcodebuild -project ./build/orc.xcodeproj -scheme orc_orc -configuration Release -hideShellScriptEnvironment
       - name: 🛠️ orc_test
+        id: build-orc_test
         run: |
           # xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -hideShellScriptEnvironment
       - name: 🏃 orc_test
+        id: run-orc_test
         run: |
           # /usr/bin/time -l ./build/Release/orc_test ./test/battery
       - name: 🛠️ orc_test w/ ASan

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build-and-test:
     runs-on: macos-latest
+    continue-on-error: true
     steps:
       - name: 🐍 setup
         uses: actions/setup-python@v2
@@ -21,39 +22,45 @@ jobs:
         run: |
           mkdir build
           cd build
-          # cmake -DORC_BUILD_EXAMPLES=0 -GXcode ..
+          cmake -DORC_BUILD_EXAMPLES=0 -GXcode ..
       - name: 🛠️ orc debug
         id: build-orc-debug
         run: |
-          # xcodebuild -project ./build/orc.xcodeproj -scheme orc_orc -configuration Debug -hideShellScriptEnvironment
+          xcodebuild -project ./build/orc.xcodeproj -scheme orc_orc -configuration Debug -hideShellScriptEnvironment
       - name: 🛠️ orc release
         id: build-orc-release
         run: |
-          # xcodebuild -project ./build/orc.xcodeproj -scheme orc_orc -configuration Release -hideShellScriptEnvironment
+          xcodebuild -project ./build/orc.xcodeproj -scheme orc_orc -configuration Release -hideShellScriptEnvironment
       - name: 🛠️ orc_test
         id: build-orc_test
         run: |
-          # xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -hideShellScriptEnvironment
+          xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -hideShellScriptEnvironment
       - name: 🏃 orc_test
         id: run-orc_test
         run: |
-          # /usr/bin/time -l ./build/Release/orc_test ./test/battery
+          /usr/bin/time -l ./build/Release/orc_test ./test/battery
       - name: 🛠️ orc_test w/ ASan
+        id: build-orc_test-asan
         run: |
           # xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableAddressSanitizer YES -hideShellScriptEnvironment
       - name: 🏃 orc_test w/ ASan
+        id: run-orc_test-asan
         run: |
           # ./build/Release/orc_test ./test/battery
       - name: 🛠️ orc_test w/ TSan
+        id: build-orc_test-tsan
         run: |
           # xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableThreadSanitizer YES -hideShellScriptEnvironment
       - name: 🏃 orc_test w/ TSan
+        id: run-orc_test-tsan
         run: |
           # ./build/Release/orc_test ./test/battery
       - name: 🛠️ orc_test w/ UBSan
+        id: build-orc_test-ubsan
         run: |
           # xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableUndefinedBehaviorSanitizer YES -hideShellScriptEnvironment
       - name: 🏃 orc_test w/ UBSan
+        id: run-orc_test-ubsan
         run: |
           # ./build/Release/orc_test ./test/battery
       - name: ✏️ github json

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,16 +13,9 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - name: ✍️ job summary
-        run: |
-          echo '# Job Summary' >> $GITHUB_STEP_SUMMARY
-          echo '| Run | Result | Notes |' >> $GITHUB_STEP_SUMMARY
-          echo '|---|---|---|' >> $GITHUB_STEP_SUMMARY
       - name: ⬇️ sources
         id: checkout
         uses: actions/checkout@v3
-      - name: ✍️ job summary
-        run: echo '| Checkout | ${{ steps.checkout.outcome }} | |' >> $GITHUB_STEP_SUMMARY
       - name: 🏗️ project files
         run: |
           mkdir build
@@ -60,4 +53,4 @@ jobs:
           # ./build/Release/orc_test ./test/battery
       - name: ✍️ job summary
         run: |
-          python ${GITHUB_WORKSPACE}/.github/generate_job_summary.py $GITHUB_STEP_SUMMARY ${{ toJSON(steps) }}
+          python ${GITHUB_WORKSPACE}/.github/generate_job_summary.py $GITHUB_STEP_SUMMARY ${{ steps }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -53,4 +53,4 @@ jobs:
           # ./build/Release/orc_test ./test/battery
       - name: ✍️ job summary
         run: |
-          python ${GITHUB_WORKSPACE}/.github/generate_job_summary.py $GITHUB_STEP_SUMMARY '${{ toJSON(steps) }}'
+          python ${GITHUB_WORKSPACE}/.github/generate_job_summary.py $GITHUB_STEP_SUMMARY '${{ toJSON(github) }}' '${{ toJSON(job) }}' '${{ toJSON(steps) }}' '${{ toJSON(runner) }}' '${{ toJSON(strategy) }}' '${{ toJSON(matrix) }}'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,9 +10,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Updating Action Summary
-        run: echo '# Job Summary' >> $GITHUB_STEP_SUMMARY
-        run: echo '| Run | Result | Notes |' >> $GITHUB_STEP_SUMMARY
-        run: echo '|---|---|---|' >> $GITHUB_STEP_SUMMARY
+        run: |
+          echo '# Job Summary' >> $GITHUB_STEP_SUMMARY
+          echo '| Run | Result | Notes |' >> $GITHUB_STEP_SUMMARY
+          echo '|---|---|---|' >> $GITHUB_STEP_SUMMARY
       - name: ⬇️ sources
         id: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -53,4 +53,10 @@ jobs:
           # ./build/Release/orc_test ./test/battery
       - name: ✍️ job summary
         run: |
-          python ${GITHUB_WORKSPACE}/.github/generate_job_summary.py $GITHUB_STEP_SUMMARY '${{ toJSON(github) }}' '${{ toJSON(job) }}' '${{ toJSON(steps) }}' '${{ toJSON(runner) }}' '${{ toJSON(strategy) }}' '${{ toJSON(matrix) }}'
+          echo "${{ toJSON(github) }}" > github.json
+          echo "${{ toJSON(job) }}" > job.json
+          echo "${{ toJSON(steps) }}" > steps.json
+          echo "${{ toJSON(runner) }}" > runner.json
+          echo "${{ toJSON(strategy) }}" > strategy.json
+          echo "${{ toJSON(matrix) }}" > matrix.json
+          python ${GITHUB_WORKSPACE}/.github/generate_job_summary.py $GITHUB_STEP_SUMMARY github.json job.json steps.json runner.json strategy.json matrix.json

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -60,4 +60,4 @@ jobs:
           # ./build/Release/orc_test ./test/battery
       - name: ✍️ job summary
         run: |
-          python generate_job_summary.py $GITHUB_STEP_SUMMARY ${{ toJSON(steps) }}
+          python ${GITHUB_WORKSPACE}/.github/generate_job_summary.py $GITHUB_STEP_SUMMARY ${{ toJSON(steps) }}

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -414,7 +414,7 @@ int main(int argc, char** argv) try {
         std::cerr << "Usage: " << argv[0] << " /path/to/test/battery/\n";
         throw std::runtime_error("no path to test battery given");
     }
-
+x
     std::filesystem::path battery_path{argv[1]};
 
     if (!exists(battery_path) || !is_directory(battery_path)) {

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -414,7 +414,7 @@ int main(int argc, char** argv) try {
         std::cerr << "Usage: " << argv[0] << " /path/to/test/battery/\n";
         throw std::runtime_error("no path to test battery given");
     }
-x
+
     std::filesystem::path battery_path{argv[1]};
 
     if (!exists(battery_path) || !is_directory(battery_path)) {


### PR DESCRIPTION
Adding a job summary to the build and test workflow. See:

- [Supercharging GitHub Actions with Job Summaries](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/)
- [Adding a Job Summary](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary)

The gist of this PR is that a job is subdivided into individual steps, whose summaries are stored in a runtime object. We serialize that object to disk, then run the custom `generate_job_summary.py` file. That will process the `steps.json` output and generate a matrix showing the success/failure of each step.

(The next phase of this work is to teach `orc_test` to output useful summaries to disk as a JSON blob, then read those values in `generate_job_summary.py` as well. That way the action summary can include specific test details. We can also output build failures in a similar fashion.)