### PR TITLE
Object Ancestry Reporting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,8 +60,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_XCODE_GENERATE_SCHEME OFF)
 
 file(GLOB SRC_FILES CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/src/*.cpp)
+file(GLOB HEADER_FILES CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/include/orc/*.hpp)
 
-add_executable(orc_orc ${SRC_FILES})
+add_executable(orc_orc ${SRC_FILES} ${HEADER_FILES})
 add_executable(orc::orc ALIAS orc_orc)
 
 set_target_properties(orc_orc PROPERTIES OUTPUT_NAME "orc")

--- a/_orc-config
+++ b/_orc-config
@@ -28,7 +28,7 @@ filter_redundant = true
 #
 # The default value is `true`.
 
-forward_to_linker = true
+forward_to_linker = false
 
 # Print the symbol paths as they are processed by ORC. Setting this value to `true` will result in
 # copious output. Because this can produce such a flurry of information, it is tracked separately
@@ -48,7 +48,7 @@ print_symbol_paths = false
 #
 # The default value is `'warning'`.
 
-log_level = 'warning'
+log_level = 'verbose'
 
 # Output a die-count-based progress update throughout the session.
 #
@@ -61,7 +61,7 @@ show_progress = false
 #
 # The default value is `false`.
 
-standalone_mode = false
+standalone_mode = true
 
 # If defined, ORC will log output to the specified file. (Normal stream output 
 # is unaffected by the `output_file`.) 

--- a/_orc-config
+++ b/_orc-config
@@ -28,7 +28,7 @@ filter_redundant = true
 #
 # The default value is `true`.
 
-forward_to_linker = false
+forward_to_linker = true
 
 # Print the symbol paths as they are processed by ORC. Setting this value to `true` will result in
 # copious output. Because this can produce such a flurry of information, it is tracked separately
@@ -48,7 +48,7 @@ print_symbol_paths = false
 #
 # The default value is `'warning'`.
 
-log_level = 'verbose'
+log_level = 'warning'
 
 # Output a die-count-based progress update throughout the session.
 #
@@ -61,7 +61,7 @@ show_progress = false
 #
 # The default value is `false`.
 
-standalone_mode = true
+standalone_mode = false
 
 # If defined, ORC will log output to the specified file. (Normal stream output 
 # is unaffected by the `output_file`.) 

--- a/include/orc/ar.hpp
+++ b/include/orc/ar.hpp
@@ -14,7 +14,7 @@
 
 /**************************************************************************************************/
 
-void read_ar(const std::string& object_name,
+void read_ar(object_ancestry&& ancestry,
              freader& s,
              std::istream::pos_type end_pos,
              file_details details,

--- a/include/orc/dwarf.hpp
+++ b/include/orc/dwarf.hpp
@@ -16,7 +16,7 @@
 /**************************************************************************************************/
 
 struct dwarf {
-    dwarf(const std::string& object_file,
+    dwarf(object_ancestry&& ancestry,
           freader& s,
           const file_details& details,
           callbacks callbacks);

--- a/include/orc/dwarf_structs.hpp
+++ b/include/orc/dwarf_structs.hpp
@@ -8,10 +8,10 @@
 
 // stdc++
 #include <array>
-#include <cstdint>
-#include <vector>
-#include <string>
 #include <cassert>
+#include <cstdint>
+#include <string>
+#include <vector>
 
 // application
 #include "orc/dwarf_constants.hpp"
@@ -28,22 +28,21 @@ struct freader;
 // have both values around (especially in the DIE reference case.)
 struct attribute_value {
     enum class type {
-        none      = 0,
-        passover  = 1 << 0,
-        uint      = 1 << 1,
-        sint      = 1 << 2,
-        string    = 1 << 3,
+        none = 0,
+        passover = 1 << 0,
+        uint = 1 << 1,
+        sint = 1 << 2,
+        string = 1 << 3,
         reference = 1 << 4,
-        die       = 1 << 5,
+        die = 1 << 5,
     };
     using ut = typename std::underlying_type<type>::type;
 
     friend auto operator|=(type& x, const type& y) {
-        return reinterpret_cast<enum type&>(reinterpret_cast<ut&>(x) |= reinterpret_cast<const ut&>(y));
+        return reinterpret_cast<enum type&>(reinterpret_cast<ut&>(x) |=
+                                            reinterpret_cast<const ut&>(y));
     }
-    friend auto has_type(type x, type y) {
-        return (static_cast<ut>(x) & static_cast<ut>(y)) != 0;
-    }
+    friend auto has_type(type x, type y) { return (static_cast<ut>(x) & static_cast<ut>(y)) != 0; }
 
     void passover() { _type = type::passover; }
 
@@ -187,7 +186,10 @@ struct object_ancestry {
 
     auto begin() const { return _ancestors.begin(); }
     auto end() const { return begin() + _count; }
-    auto& back() { assert(_count); return _ancestors[_count]; }
+    auto& back() {
+        assert(_count);
+        return _ancestors[_count];
+    }
 
     void emplace_back(pool_string&& ancestor) {
         assert((_count + 1) < _ancestors.size());
@@ -257,18 +259,10 @@ struct die {
         return attribute_has_type(at, attribute_value::type::die);
     }
 
-    auto attribute_uint(dw::at at) const {
-        return attribute(at)._value.uint();
-    }
-    const auto& attribute_string(dw::at at) const {
-        return attribute(at)._value.string();
-    }
-    auto attribute_reference(dw::at at) const {
-        return attribute(at)._value.reference();
-    }
-    const auto& attribute_die(dw::at at) const {
-        return attribute(at)._value.die();
-    }
+    auto attribute_uint(dw::at at) const { return attribute(at)._value.uint(); }
+    const auto& attribute_string(dw::at at) const { return attribute(at)._value.string(); }
+    auto attribute_reference(dw::at at) const { return attribute(at)._value.reference(); }
+    const auto& attribute_die(dw::at at) const { return attribute(at)._value.die(); }
 };
 
 std::ostream& operator<<(std::ostream& s, const die& x);

--- a/include/orc/dwarf_structs.hpp
+++ b/include/orc/dwarf_structs.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 // stdc++
+#include <array>
 #include <cstdint>
 #include <vector>
 #include <string>
@@ -179,6 +180,22 @@ enum class arch : std::uint8_t {
 const char* to_string(arch arch);
 
 /**************************************************************************************************/
+
+struct object_ancestry {
+    std::array<pool_string, 5> _ancestors;
+    std::size_t _count{0};
+
+    auto begin() const { return _ancestors.begin(); }
+    auto end() const { return begin() + _count; }
+    auto& back() { assert(_count); return _ancestors[_count]; }
+
+    void emplace_back(pool_string&& ancestor) {
+        assert((_count + 1) < _ancestors.size());
+        _ancestors[_count++] = std::move(ancestor);
+    }
+};
+
+/**************************************************************************************************/
 // A die is constructed by reading an abbreviation entry, then filling in the abbreviation's
 // attribute values with data taken from _debug_info. Thus it is possible for more than one die to
 // use the same abbreviation, but because the die is listed in a different place in the debug_info
@@ -187,7 +204,7 @@ struct die {
     // Because the quantity of these created at runtime can beon the order of millions of instances,
     // these are ordered for optimal alignment. If you change the ordering, or add/remove items
     // here, please consider alignment issues.
-    pool_string _object_file;
+    object_ancestry _ancestry;
     pool_string _path;
     attribute* _attributes;
     std::size_t _attributes_size{0};

--- a/include/orc/fat.hpp
+++ b/include/orc/fat.hpp
@@ -14,7 +14,7 @@
 
 /**************************************************************************************************/
 
-void read_fat(const std::string& object_name,
+void read_fat(object_ancestry&& ancestry,
               freader& s,
               std::istream::pos_type end_pos,
               file_details details,

--- a/include/orc/macho.hpp
+++ b/include/orc/macho.hpp
@@ -14,7 +14,7 @@
 
 /**************************************************************************************************/
 
-void read_macho(std::string object_name,
+void read_macho(object_ancestry&& ancestry,
                 freader s,
                 std::istream::pos_type end_pos,
                 file_details details,

--- a/include/orc/parse_file.hpp
+++ b/include/orc/parse_file.hpp
@@ -220,7 +220,13 @@ std::uint32_t uleb128(freader& s);
 std::int32_t sleb128(freader& s);
 
 /**************************************************************************************************/
-
+/*
+    For functions that take values by rvalue reference (aka sink functions), it can be helpful to be
+    explicit about the object being passed in. In such cases, the object can only be moved or
+    copied. C++ already provides a `move` routine; this is the `copy` equivalent. It is more
+    helpful than passing T(x) (which would create a copy of x) because, at a minimum, it is more
+    explicit about the intent of the call.
+*/
 template <typename T>
 constexpr std::decay_t<T> copy(T&& value) noexcept(
     noexcept(std::decay_t<T>{static_cast<T&&>(value)})) {

--- a/include/orc/parse_file.hpp
+++ b/include/orc/parse_file.hpp
@@ -44,7 +44,7 @@ inline std::size_t hash_combine(std::size_t seed, const T& x) {
     return seed ^ std::hash<T>{}(x) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
 }
 
-template <class T, class ... Args>
+template <class T, class... Args>
 inline std::size_t hash_combine(std::size_t seed, const T& x, Args&&... args) {
     // This routine reduces the argument count by 1 by hashing `x` into the seed, and calling
     // hash_combine on the remaining arguments and the new seed. Eventually Args will disintegrate
@@ -110,7 +110,8 @@ struct freader {
     std::string_view read_c_string_view() {
         assert(*this);
         auto f = _p;
-        for (; *_p; ++_p) {}
+        for (; *_p; ++_p) {
+        }
         auto n = _p++ - f;
         return std::string_view(f, n);
     }
@@ -131,6 +132,7 @@ auto temp_seek(freader& s, std::istream::off_type offset, std::ios::seekdir dir,
     struct posmark {
         explicit posmark(freader& s) : _s{s}, _pos{_s.tellg()} {}
         ~posmark() { _s.seekg(_pos); }
+
     private:
         freader& _s;
         std::size_t _pos;
@@ -228,10 +230,10 @@ std::int32_t sleb128(freader& s);
     explicit about the intent of the call.
 */
 template <typename T>
-constexpr std::decay_t<T> copy(T&& value) noexcept(
-    noexcept(std::decay_t<T>{static_cast<T&&>(value)})) {
-  static_assert(!std::is_same<std::decay_t<T>, T>::value, "explicit copy of rvalue.");
-  return std::decay_t<T>{static_cast<T&&>(value)};
+constexpr std::decay_t<T> copy(T&& value) noexcept(noexcept(std::decay_t<T>{
+    static_cast<T&&>(value)})) {
+    static_assert(!std::is_same<std::decay_t<T>, T>::value, "explicit copy of rvalue.");
+    return std::decay_t<T>{static_cast<T&&>(value)};
 }
 
 /**************************************************************************************************/

--- a/include/orc/parse_file.hpp
+++ b/include/orc/parse_file.hpp
@@ -249,7 +249,7 @@ struct callbacks {
     empool_callback _empool;
 };
 
-void parse_file(const std::string& object_name,
+void parse_file(std::string_view object_name,
                 const object_ancestry& ancestry,
                 freader& s,
                 std::istream::pos_type end_pos,

--- a/include/orc/parse_file.hpp
+++ b/include/orc/parse_file.hpp
@@ -221,6 +221,15 @@ std::int32_t sleb128(freader& s);
 
 /**************************************************************************************************/
 
+template <typename T>
+constexpr std::decay_t<T> copy(T&& value) noexcept(
+    noexcept(std::decay_t<T>{static_cast<T&&>(value)})) {
+  static_assert(!std::is_same<std::decay_t<T>, T>::value, "explicit copy of rvalue.");
+  return std::decay_t<T>{static_cast<T&&>(value)};
+}
+
+/**************************************************************************************************/
+
 using dies = std::vector<die>;
 using register_dies_callback = std::function<void(dies)>;
 using do_work_callback = std::function<void(std::function<void()>)>;
@@ -233,6 +242,7 @@ struct callbacks {
 };
 
 void parse_file(const std::string& object_name,
+                const object_ancestry& ancestry,
                 freader& s,
                 std::istream::pos_type end_pos,
                 callbacks callbacks);

--- a/src/ar.cpp
+++ b/src/ar.cpp
@@ -29,7 +29,7 @@ std::string read_string(freader& s, std::size_t n) {
 
 /**************************************************************************************************/
 
-void read_ar(const std::string&,
+void read_ar(object_ancestry&& ancestry,
              freader& s,
              std::istream::pos_type end_pos,
              file_details details,
@@ -56,7 +56,7 @@ void read_ar(const std::string&,
 
         if (identifier.rfind(".o") == identifier.size() - 2) {
             auto end_pos = s.tellg() + static_cast<std::streamoff>(file_size);
-            parse_file(identifier, s, end_pos, callbacks);
+            parse_file(identifier, ancestry, s, end_pos, callbacks);
             s.seekg(end_pos); // parse_file could leave the read head anywhere.
         } else {
             // skip to next file in the archive.

--- a/src/dwarf_structs.cpp
+++ b/src/dwarf_structs.cpp
@@ -80,7 +80,9 @@ std::ostream& operator<<(std::ostream& s, const die& x) {
     std::string def_loc;
     std::vector<attribute> attributes(x._attributes, x._attributes + x._attributes_size);
 
-    s << "compilation unit: " << x._object_file.allocate_path().filename().string() << ":\n";
+    for (const auto& ancestor: x._ancestry) {
+        s << "    within: " << ancestor.allocate_path().filename().string() << ":\n";
+    }
 
     auto erase_attr = [](auto& attributes, auto key){
         auto found = std::find_if(attributes.begin(), attributes.end(), [&](auto& x){

--- a/src/fat.cpp
+++ b/src/fat.cpp
@@ -38,6 +38,16 @@ struct fat_arch_64 {
 
 /**************************************************************************************************/
 
+const char* magic_to_string(std::uint32_t magic) {
+    switch (magic) {
+        case FAT_MAGIC: return "fat32";
+        case FAT_MAGIC_64: return "fat64";
+        default: assert(false);
+    }
+}
+
+/**************************************************************************************************/
+
 } // namespace
 
 /**************************************************************************************************/
@@ -86,7 +96,7 @@ void read_fat(object_ancestry&& ancestry,
         }
 
         temp_seek(s, offset, [&] {
-            parse_file(std::to_string(header.magic),
+            parse_file(magic_to_string(header.magic),
                        ancestry,
                        s,
                        s.tellg() + static_cast<std::streamoff>(size),

--- a/src/fat.cpp
+++ b/src/fat.cpp
@@ -42,7 +42,7 @@ struct fat_arch_64 {
 
 /**************************************************************************************************/
 
-void read_fat(const std::string& object_name,
+void read_fat(object_ancestry&& ancestry,
               freader& s,
               std::istream::pos_type end_pos,
               file_details details,
@@ -86,7 +86,11 @@ void read_fat(const std::string& object_name,
         }
 
         temp_seek(s, offset, [&] {
-            parse_file(object_name, s, s.tellg() + static_cast<std::streamoff>(size), callbacks);
+            parse_file(std::to_string(header.magic),
+                       ancestry,
+                       s,
+                       s.tellg() + static_cast<std::streamoff>(size),
+                       callbacks);
         });
     }
 }

--- a/src/macho.cpp
+++ b/src/macho.cpp
@@ -160,12 +160,12 @@ struct mach_header {
 
 /**************************************************************************************************/
 
-void read_macho(std::string object_name,
+void read_macho(object_ancestry&& ancestry,
                 freader s,
                 std::istream::pos_type end_pos,
                 file_details details,
                 callbacks callbacks) {
-    callbacks._do_work([_object_name = std::move(object_name),
+    callbacks._do_work([_ancestry = std::move(ancestry),
                         _s = std::move(s),
                         _details = std::move(details),
                         _callbacks = std::move(callbacks)]() mutable {
@@ -203,7 +203,7 @@ void read_macho(std::string object_name,
         // REVISIT: (fbrereto) I'm not happy that dwarf is an out-arg to read_load_command.
         // Maybe pass in some kind of lambda that'll get called when a relevant DWARF section
         // is found? A problem for later...
-        dwarf dwarf(_object_name, _s, std::move(_details), std::move(_callbacks));
+        dwarf dwarf(std::move(_ancestry), _s, std::move(_details), std::move(_callbacks));
 
         for (std::size_t i = 0; i < load_command_sz; ++i) {
             read_load_command(_s, _details, dwarf);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -384,17 +384,12 @@ auto epilogue(bool exception) {
 
     if (log_level_at_least(settings::log_level::info)) {
         cout_safe([&](auto& s){
-            s << "info: ORC complete " << g._odrv_count << " ODRVs reported\n";
+            s << "info: ORC complete.\n"
+              << "info:   " << g._odrv_count << " ODRVs reported\n"
+              << "info:   " << g._object_file_count << " compilation units processed\n"
+              << "info:   " << g._die_processed_count << " dies processed\n"
+              << "info:   " << g._die_registered_count << " dies registered\n";
         });
-
-        if (log_level_at_least(settings::log_level::verbose)) {
-            cout_safe([&](auto& s){
-            s   << "verbose: additional stats:\n"
-                << "  " << g._object_file_count << " compilation units processed\n"
-                << "  " << g._die_processed_count << " dies processed\n"
-                << "  " << g._die_registered_count << " dies registered\n";
-            });
-        }
     }
 
     if (exception || g._odrv_count != 0) {

--- a/src/parse_file.cpp
+++ b/src/parse_file.cpp
@@ -151,20 +151,25 @@ std::int32_t sleb128(freader& s) {
 /**************************************************************************************************/
 
 void parse_file(const std::string& object_name,
+                const object_ancestry& ancestry,
                 freader& s,
                 std::istream::pos_type end_pos,
                 callbacks callbacks) {
     auto detection = detect_file(s);
 
+    // append this object name to the ancestry
+    object_ancestry new_ancestry = ancestry;
+    new_ancestry.emplace_back(callbacks._empool(object_name));
+
     switch (detection._format) {
         case file_details::format::unknown:
             throw std::runtime_error("unknown format");
         case file_details::format::macho:
-            return read_macho(object_name, s, end_pos, std::move(detection), std::move(callbacks));
+            return read_macho(std::move(new_ancestry), s, end_pos, std::move(detection), std::move(callbacks));
         case file_details::format::ar:
-            return read_ar(object_name, s, end_pos, std::move(detection), std::move(callbacks));
+            return read_ar(std::move(new_ancestry), s, end_pos, std::move(detection), std::move(callbacks));
         case file_details::format::fat:
-            return read_fat(object_name, s, end_pos, std::move(detection), std::move(callbacks));
+            return read_fat(std::move(new_ancestry), s, end_pos, std::move(detection), std::move(callbacks));
     }
 }
 

--- a/src/parse_file.cpp
+++ b/src/parse_file.cpp
@@ -150,7 +150,7 @@ std::int32_t sleb128(freader& s) {
 
 /**************************************************************************************************/
 
-void parse_file(const std::string& object_name,
+void parse_file(std::string_view object_name,
                 const object_ancestry& ancestry,
                 freader& s,
                 std::istream::pos_type end_pos,


### PR DESCRIPTION
## Description

Previously in an ORC report, we were only outputting the direct object file where a symbol is located:

```
error: ODRV (member:data_member_location); conflict in `...`
    compilation unit: my_object_file.o:
        definition location: ...
        name: ...
        type: ...
        data_member_location: ...
        accessibility: ...
```

However the location of this object file could be buried in a hierarchy of files and subfiles: the object file may be within a fat `macho` section contained within an `ar` file that represents a static library. It would be helpful, then, if ORC printed out this entire "ancestry" tree when outputting a report, not just the leaf node of it.

Now the output looks something like:

```
error: ODRV (member:data_member_location); conflict in `...`
    within: my_library.a:
    within: my_object_file.o:
        definition location: ...
        name: ...
        type: ...
        data_member_location: ...
        accessibility: ...
```

The current PR keeps track of up to 5 ancestors, which can be easily extended if need be.
