### PR TITLE
Improved declaration die processing

### DIFF
--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -21,15 +21,16 @@ if __name__ == "__main__":
     print("| Run | Result | Notes |")
     print("|---|---|---|")
 
-    failure = False
+    all_success = True
 
     for key in steps:
         value = steps[key];
         outcome = value['outcome']
-        failure |= outcome == 'success'
-        outcome_emoji = ":green_circle:" if outcome == 'success' else ":red_circle:"
+        cur_success = outcome == 'success'
+        all_success &= cur_success
+        outcome_emoji = ":green_circle:" if cur_success else ":red_circle:"
         outputs = value['outputs']
         print(f"| {key} | {outcome_emoji} {outcome} | {outputs} |")
 
-    if failure:
+    if not all_success:
         sys.exit("One or more tests failed")

--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
 
     print("## Details")
     print(f"- started by: `{github['actor']}`")
-    if "event" in github && "pull_request" in github['event']:
+    if "event" in github and "pull_request" in github['event']:
         print(f"- branch: `{github['event']['pull_request']['head']['ref']}`")
     print(f"- action: `{github['event']['action']}`")
 

--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -9,10 +9,9 @@ if __name__ == "__main__":
     print(f"# {github['workflow']}: Job Summary")
     print("")
 
-
     print("## Details")
     print(f"- started by: `{github['actor']}`")
-    if (github['event']['pull_request']):
+    if "event" in github && "pull_request" in github['event']:
         print(f"- branch: `{github['event']['pull_request']['head']['ref']}`")
     print(f"- action: `{github['event']['action']}`")
 
@@ -22,9 +21,17 @@ if __name__ == "__main__":
     print("| Run | Result | Notes |")
     print("|---|---|---|")
 
+    failure = False
+
     for key in steps:
         value = steps[key];
         outcome = value['outcome']
+        failure |= outcome == 'success'
         outcome_emoji = ":green_circle:" if outcome == 'success' else ":red_circle:"
         outputs = value['outputs']
         print(f"| {key} | {outcome_emoji} {outcome} | {outputs} |")
+
+    if failure:
+        exit 1
+    else:
+        exit 0

--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -32,6 +32,4 @@ if __name__ == "__main__":
         print(f"| {key} | {outcome_emoji} {outcome} | {outputs} |")
 
     if failure:
-        exit 1
-    else:
-        exit 0
+        sys.exit("One or more tests failed")

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -86,6 +86,6 @@ jobs:
           name: "steps.json"
           json: ${{ toJSON(steps) }}
       - name: ✍️ job summary
-        continue-on-error: true
+        continue-on-error: false
         run: |
           python ${GITHUB_WORKSPACE}/.github/generate_job_summary.py $GITHUB_STEP_SUMMARY github.json steps.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,10 @@ set(CMAKE_XCODE_GENERATE_SCHEME OFF)
 file(GLOB SRC_FILES CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/src/*.cpp)
 file(GLOB HEADER_FILES CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/include/orc/*.hpp)
 
-add_executable(orc_orc ${SRC_FILES} ${HEADER_FILES})
+add_executable(orc_orc
+    ${SRC_FILES}
+    ${HEADER_FILES}
+)
 add_executable(orc::orc ALIAS orc_orc)
 
 set_target_properties(orc_orc PROPERTIES OUTPUT_NAME "orc")
@@ -90,6 +93,7 @@ file(GLOB TEST_SRC_FILES CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/test/src/*.cpp)
 list(REMOVE_ITEM SRC_FILES ${PROJECT_SOURCE_DIR}/src/main.cpp)
 add_executable(orc_test
     ${SRC_FILES}
+    ${HEADER_FILES}
     ${TEST_SRC_FILES}
 )
 add_executable(orc::test ALIAS orc_test)

--- a/include/orc/dwarf_structs.hpp
+++ b/include/orc/dwarf_structs.hpp
@@ -267,4 +267,6 @@ struct die {
 
 std::ostream& operator<<(std::ostream& s, const die& x);
 
+using dies = std::vector<die>;
+
 /**************************************************************************************************/

--- a/include/orc/parse_file.hpp
+++ b/include/orc/parse_file.hpp
@@ -238,7 +238,6 @@ constexpr std::decay_t<T> copy(T&& value) noexcept(noexcept(std::decay_t<T>{
 
 /**************************************************************************************************/
 
-using dies = std::vector<die>;
 using register_dies_callback = std::function<void(dies)>;
 using do_work_callback = std::function<void(std::function<void()>)>;
 using empool_callback = std::function<pool_string(std::string_view)>;

--- a/src/dwarf_structs.cpp
+++ b/src/dwarf_structs.cpp
@@ -93,18 +93,25 @@ std::ostream& operator<<(std::ostream& s, const die& x) {
             attributes.erase(found);
     };
 
+    bool first = true;
+
     if (x.attribute_has_string(dw::at::decl_file)) {
         s << "        definition location: " << x.attribute_string(dw::at::decl_file);
         erase_attr(attributes, dw::at::decl_file);
+
+        if (x.attribute_has_uint(dw::at::decl_line)) {
+            s << ":" + std::to_string(x.attribute_uint(dw::at::decl_line));
+            erase_attr(attributes, dw::at::decl_line);
+        }
+
+        first = false;
     }
 
-    if (x.attribute_has_uint(dw::at::decl_line)) {
-        s << ":" + std::to_string(x.attribute_uint(dw::at::decl_line));
-        erase_attr(attributes, dw::at::decl_line);
-    }
 
     for (const auto& attr : attributes) {
-        s << '\n' << attr;
+        if (!first) s << '\n';
+        s << attr;
+        first = false;
     }
 
     return s;

--- a/src/fat.cpp
+++ b/src/fat.cpp
@@ -45,8 +45,9 @@ const char* cputype_to_string(cpu_type_t cputype) {
         case CPU_TYPE_X86_64: return "arch.x86_64";
         case CPU_TYPE_ARM64: return "arch.arm64";
         case CPU_TYPE_ARM64_32: return "arch.arm64_32";
-        default: return "arch.unknown";
     }
+
+    return "arch.unknown";
 }
 
 /**************************************************************************************************/

--- a/src/orc.cpp
+++ b/src/orc.cpp
@@ -157,8 +157,8 @@ bool nonfatal_attribute(dw::at at) {
 /**************************************************************************************************/
 bool type_equivalent(const attribute& x, const attribute& y);
 dw::at find_die_conflict(const die& x, const die& y) {
-    const auto& yfirst = y.begin();
-    const auto& ylast = y.end();
+    auto yfirst = y.begin();
+    auto ylast = y.end();
 
     for (const auto& xattr : x) {
         auto name = xattr._name;
@@ -173,6 +173,16 @@ dw::at find_die_conflict(const die& x, const die& y) {
         else if (xattr == yattr) continue;
 
         return name;
+    }
+
+    // Find and flag any nonfatal attributes that exist in y but not in x
+    const auto xfirst = x.begin();
+    const auto xlast = x.end();
+    for (; yfirst != ylast; ++yfirst) {
+        const auto& name = yfirst->_name;
+        if (nonfatal_attribute(name)) continue;
+        auto xfound = std::find_if(xfirst, xlast, [&](auto& x) { return name == x._name; });
+        if (xfound == xlast) return name;
     }
 
     // REVISIT (fbrereto) : There may be some attributes left over in y; should we care?

--- a/src/orc.cpp
+++ b/src/orc.cpp
@@ -218,7 +218,7 @@ dw::at find_die_conflict(const die& x, const die& y) {
         if (nonfatal_attribute(name)) continue;
 
         auto yfound = std::find_if(yfirst, ylast, [&](auto& x) { return name == x._name; });
-        if (yfound == ylast) continue; // return name;
+        if (yfound == ylast) return name;
 
         const auto& yattr = *yfound;
 
@@ -314,6 +314,9 @@ bool skip_die(const dies& dies, die& d, const std::string_view& symbol) {
 
     // we don't handle any die that's ObjC-based.
     if (d.has_attribute(dw::at::apple_runtime_class)) return true;
+
+    // don't handle declarations - only definitions
+    if (d.has_attribute(dw::at::declaration) && d.attribute_uint(dw::at::declaration) == 1) return true;
 
     // If the symbol is listed in the symbol_ignore list, we're done here.
     if (sorted_has(settings::instance()._symbol_ignore, symbol)) return true;

--- a/test/battery/calling_convention/odrv_test.toml
+++ b/test/battery/calling_convention/odrv_test.toml
@@ -16,5 +16,9 @@
     category = "structure:calling_convention"
     symbol = "object"
 
+[[odrv]]
+    category = "subprogram:virtuality"
+    symbol = "object::api() const"
+
 [orc_test_flags]
-    disable = true
+    disable = false

--- a/test/battery/calling_convention/odrv_test.toml
+++ b/test/battery/calling_convention/odrv_test.toml
@@ -17,5 +17,4 @@
     symbol = "object"
 
 [orc_test_flags]
-
-disable = false
+    disable = true


### PR DESCRIPTION
## Description

ORC was processing DIEs for declarations the same as definitions. These DIEs have a very small number of entries (just the name and a boolean designating them as a declaration) and so fail to compare to the DIE for an associated definition in almost every way. However, when they are _the first_ DIE to be registered for the type, all other DIEs for that type were failing to fail. This PR addresses two issues.

We actually don't skip over the declarations. Sometimes declarations contain useful DIE data that we want to consider for possible ODRVs. What we want to do, rather, is separate those DIEs that are for the declarations and those that are for the definitions. Since the DIE registry map uses a precomputed hash for the key of the DIEs, we now include the declaration attribute's existence in the hash, keeping declarations and definitions separated.