### PR TITLE
Fix for issue 7

### DIFF
--- a/src/orc.cpp
+++ b/src/orc.cpp
@@ -258,6 +258,11 @@ bool skip_die(const dies& dies, die& d, const std::string_view& symbol) {
     // These are the tags we don't deal with (yet, if ever.)
     if (skip_tagged_die(d)) return true;
 
+    // According to DWARF 3.3.1, a subprogram tag that is missing the external
+    // flag means the function is invisible outside its compilation unit. As
+    // such, it cannot contribute to an ODRV.
+    if (d._tag == dw::tag::subprogram && !d.has_attribute(dw::at::external)) return true;
+
     // Empty path means the die (or an ancestor) is anonymous/unnamed. No need to register
     // them.
     if (d._path.empty()) return true;

--- a/test/battery/static_free_functions/odrv_test.toml
+++ b/test/battery/static_free_functions/odrv_test.toml
@@ -1,0 +1,16 @@
+[[source]]
+    path = "src.cpp"
+    object_file_name = "static_1"
+    flags = [
+        "-DORC_TEST_FILE=1"
+    ]
+
+[[source]]
+    path = "src.cpp"
+    object_file_name = "static_2"
+    flags = [
+        "-DORC_TEST_FILE=2"
+    ]
+
+[orc_test_flags]
+    disable = false

--- a/test/battery/static_free_functions/src.cpp
+++ b/test/battery/static_free_functions/src.cpp
@@ -1,0 +1,18 @@
+static int strlen(const char* p) {
+    int n = 0;
+    while (*p++) {
+        ++n;
+    }
+    return n;
+}
+
+static int foo() {
+#if ORC_TEST_FILE == 1
+    return 42;
+#else
+    return strlen("Hello, world!");
+#endif
+}
+
+// Required so the compiler generates a symbol.
+int (*api_pointer)()  = &foo;

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -331,7 +331,7 @@ void run_battery_test(const std::filesystem::path& home) {
 
     auto expected_odrvs = derive_expected_odrvs(home, settings);
     if (expected_odrvs.empty()) {
-        throw std::runtime_error("found no expected ODRVs");
+        std::cout << "Found no expected ODRVs; expected?\n";
     }
 
     auto object_files = compile_compilation_units(home, settings, compilation_units);


### PR DESCRIPTION
## Description

According to DWARF 3.3.1, a subprogram tag that is missing the external flag means the function is invisible outside its compilation unit. As such, it cannot contribute to an ODRV. I added a check to that effect in `skip_die`, as well as an ORC test that finds no ODRVs (whereas it did before.)
