### PR TITLE
Improved GitHub Actions Output

### DIFF
--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -2,6 +2,8 @@ import sys
 import json
 
 if __name__ == "__main__":
+    print("::notice file=app.js,line=1,col=5,endColumn=7::Missing semicolon")
+
     sys.stdout = open(sys.argv[1], "w")
     github = json.load(open(sys.argv[2], "r"))
     steps = json.load(open(sys.argv[3], "r"))
@@ -23,8 +25,6 @@ if __name__ == "__main__":
     print("## Summary of Steps")
     print("| Run | Result | Notes |")
     print("|---|---|---|")
-
-    print("::notice file=app.js,line=1,col=5,endColumn=7::Missing semicolon")
 
     all_success = True
 

--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -24,6 +24,8 @@ if __name__ == "__main__":
     print("| Run | Result | Notes |")
     print("|---|---|---|")
 
+    print "::notice file=app.js,line=1,col=5,endColumn=7::Missing semicolon"
+
     all_success = True
 
     for key in steps:

--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -1,5 +1,6 @@
 import sys
 import json
+import re
 
 if __name__ == "__main__":
     sys.stdout = open(sys.argv[1], "w")
@@ -21,10 +22,11 @@ if __name__ == "__main__":
     print("")
 
     print("## Summary of Steps")
-    print("| Run | Result | Notes |")
-    print("|---|---|---|")
+    print("| Run | Result | Notes | Expected | Reported |")
+    print("|---|---|---|---|---|---|")
 
     all_success = True
+    p = re.compile('(?<!\\\\)\'')
 
     for key in steps:
         value = steps[key];
@@ -34,21 +36,27 @@ if __name__ == "__main__":
         outcome_emoji = ":green_circle:" if cur_success else ":red_circle:"
         outputs = value['outputs']
         if outputs == {}:
-            outputs = ""
+            print(f"| **{key}** | {outcome_emoji} {outcome} | _none_ |")
         else:
-            outputs_string = "<ul>"
-            for out_key in outputs:
-                outputs_string += f"<li>`{out_key}`: {outputs[out_key]}</li>"
-            outputs_string += "</ul>"
-            outputs = outputs_string
-        print(f"| {key} | {outcome_emoji} {outcome} | {outputs} |")
+            if "orc_test_out" in outputs:
+                outputs = p.sub('\"', outputs["orc_test_out"])
+                outputs = json.loads(outputs)
+                for run in outputs:
+                    if isinstance(outputs[run], list):
+                        continue
+                    expected = outputs[run]["expected"]
+                    reported = outputs[run]["reported"]
+                    outcome_emoji = ":green_circle:" if expected == reported else ":red_circle:"
+                    print(f"| `{run}` | {outcome_emoji} | | {expected} | {reported} |")
+            else:
+                print(f"| **{key}** | {outcome_emoji} {outcome} | {outputs} |")
 
     # Keep these for debugging; they can be used to serialize the various
     # environment variables available to us through GitHub Actions. Be
     # careful, though, not to leave these in production: they produce
     # copious (and possibly sensitive) output.
 
-    if True:
+    if False:
         print("## github")
         print("<code>")
         print(json.dumps(github, indent=4, sort_keys=False))

--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -36,10 +36,10 @@ if __name__ == "__main__":
         outcome_emoji = ":green_circle:" if cur_success else ":red_circle:"
         outputs = value['outputs']
         if outputs == {}:
-            print(f"| **{key}** | {outcome_emoji} {outcome} | _none_ | | |")
+            print(f"| **{key}** | | {outcome_emoji} {outcome} | | |")
         else:
             if "orc_test_out" in outputs:
-                print(f"| **{key}** | {outcome_emoji} {outcome} | _details below_ | | |")
+                print(f"| **{key}** | | {outcome_emoji} {outcome} | | |")
                 outputs = p.sub('\"', outputs["orc_test_out"])
                 outputs = json.loads(outputs)
                 for run in outputs:
@@ -50,7 +50,7 @@ if __name__ == "__main__":
                     outcome_emoji = ":green_circle:" if expected == reported else ":red_circle:"
                     print(f"| | `{run}` | {outcome_emoji} | {expected} | {reported} |")
             else:
-                print(f"| **{key}** | {outcome_emoji} {outcome} | {outputs} | | |")
+                print(f"| **{key}** | | {outcome_emoji} {outcome} {outputs} | | |")
 
     # Keep these for debugging; they can be used to serialize the various
     # environment variables available to us through GitHub Actions. Be

--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
 
     print("## Summary of Steps")
     print("| Run | Result | Notes | Expected | Reported |")
-    print("|---|---|---|---|---|---|")
+    print("|---|---|---|---|---|")
 
     all_success = True
     p = re.compile('(?<!\\\\)\'')
@@ -36,9 +36,10 @@ if __name__ == "__main__":
         outcome_emoji = ":green_circle:" if cur_success else ":red_circle:"
         outputs = value['outputs']
         if outputs == {}:
-            print(f"| **{key}** | {outcome_emoji} {outcome} | _none_ |")
+            print(f"| **{key}** | {outcome_emoji} {outcome} | _none_ | | |")
         else:
             if "orc_test_out" in outputs:
+                print(f"| **{key}** | {outcome_emoji} {outcome} | _details below_ | | |")
                 outputs = p.sub('\"', outputs["orc_test_out"])
                 outputs = json.loads(outputs)
                 for run in outputs:
@@ -49,7 +50,7 @@ if __name__ == "__main__":
                     outcome_emoji = ":green_circle:" if expected == reported else ":red_circle:"
                     print(f"| `{run}` | {outcome_emoji} | | {expected} | {reported} |")
             else:
-                print(f"| **{key}** | {outcome_emoji} {outcome} | {outputs} |")
+                print(f"| **{key}** | {outcome_emoji} {outcome} | {outputs} | | |")
 
     # Keep these for debugging; they can be used to serialize the various
     # environment variables available to us through GitHub Actions. Be

--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -2,8 +2,6 @@ import sys
 import json
 
 if __name__ == "__main__":
-    print("::notice file=app.js,line=1,col=5,endColumn=7::Missing semicolon")
-
     sys.stdout = open(sys.argv[1], "w")
     github = json.load(open(sys.argv[2], "r"))
     steps = json.load(open(sys.argv[3], "r"))
@@ -35,7 +33,19 @@ if __name__ == "__main__":
         all_success &= cur_success
         outcome_emoji = ":green_circle:" if cur_success else ":red_circle:"
         outputs = value['outputs']
+        if outputs == {}:
+            outputs = ""
+        else:
+            outputs_string = "<ol>"
+            for key in outputs:
+                outputs_string += f"<li>{key}: {outputs[key]}</li>"
+            outputs_string = "</ol>"
+            outputs = outputs_string
         print(f"| {key} | {outcome_emoji} {outcome} | {outputs} |")
+
+    print("<code>")
+    print(json.dumps(steps, indent=4, sort_keys=False))
+    print("</code>")
 
     if not all_success:
         sys.exit("One or more tests failed")

--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -43,9 +43,18 @@ if __name__ == "__main__":
             outputs = outputs_string
         print(f"| {key} | {outcome_emoji} {outcome} | {outputs} |")
 
-    print("<code>")
-    print(json.dumps(steps, indent=4, sort_keys=False))
-    print("</code>")
+    # Keep these for debugging; they can be used to serialize the various
+    # environment variables available to us through GitHub Actions.
+    if True:
+        print("## github")
+        print("<code>")
+        print(json.dumps(github, indent=4, sort_keys=False))
+        print("</code>")
+
+        print("## steps")
+        print("<code>")
+        print(json.dumps(steps, indent=4, sort_keys=False))
+        print("</code>")
 
     if not all_success:
         sys.exit("One or more tests failed")

--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
                         continue
                     expected = outputs[run]["expected"]
                     reported = outputs[run]["reported"]
-                    outcome_emoji = ":green_circle:" if expected == reported else ":red_circle:"
+                    outcome_emoji = ":green_circle: success" if expected == reported else ":red_circle: failure"
                     print(f"| | `{run}` | {outcome_emoji} | {expected} | {reported} |")
             else:
                 print(f"| **{key}** | | {outcome_emoji} {outcome} {outputs} | | |")

--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -22,7 +22,7 @@ if __name__ == "__main__":
     print("")
 
     print("## Summary of Steps")
-    print("| Run | Result | Notes | Expected | Reported |")
+    print("| Step | Test | Notes | Expected | Reported |")
     print("|---|---|---|---|---|")
 
     all_success = True
@@ -48,7 +48,7 @@ if __name__ == "__main__":
                     expected = outputs[run]["expected"]
                     reported = outputs[run]["reported"]
                     outcome_emoji = ":green_circle:" if expected == reported else ":red_circle:"
-                    print(f"| `{run}` | {outcome_emoji} | | {expected} | {reported} |")
+                    print(f"| | `{run}` | {outcome_emoji} | {expected} | {reported} |")
             else:
                 print(f"| **{key}** | {outcome_emoji} {outcome} | {outputs} | | |")
 

--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -48,7 +48,7 @@ if __name__ == "__main__":
     # careful, though, not to leave these in production: they produce
     # copious (and possibly sensitive) output.
 
-    if False:
+    if True:
         print("## github")
         print("<code>")
         print(json.dumps(github, indent=4, sort_keys=False))

--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -36,16 +36,19 @@ if __name__ == "__main__":
         if outputs == {}:
             outputs = ""
         else:
-            outputs_string = "<ol>"
-            for key in outputs:
-                outputs_string += f"<li>{key}: {outputs[key]}</li>"
-            outputs_string = "</ol>"
+            outputs_string = "<ul>"
+            for out_key in outputs:
+                outputs_string += f"<li>`{out_key}`: {outputs[out_key]}</li>"
+            outputs_string += "</ul>"
             outputs = outputs_string
         print(f"| {key} | {outcome_emoji} {outcome} | {outputs} |")
 
     # Keep these for debugging; they can be used to serialize the various
-    # environment variables available to us through GitHub Actions.
-    if True:
+    # environment variables available to us through GitHub Actions. Be
+    # careful, though, not to leave these in production: they produce
+    # copious (and possibly sensitive) output.
+
+    if False:
         print("## github")
         print("<code>")
         print(json.dumps(github, indent=4, sort_keys=False))

--- a/.github/generate_job_summary.py
+++ b/.github/generate_job_summary.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
     print("| Run | Result | Notes |")
     print("|---|---|---|")
 
-    print "::notice file=app.js,line=1,col=5,endColumn=7::Missing semicolon"
+    print("::notice file=app.js,line=1,col=5,endColumn=7::Missing semicolon")
 
     all_success = True
 

--- a/.github/orc_test_to_github_actions.py
+++ b/.github/orc_test_to_github_actions.py
@@ -1,0 +1,7 @@
+import sys
+import json
+
+if __name__ == "__main__":
+    step_name = sys.argv[1];
+    test_results = json.load(open(sys.argv[2], "r"))
+    print(f"::set-output step_name::{test_results}");

--- a/.github/orc_test_to_github_actions.py
+++ b/.github/orc_test_to_github_actions.py
@@ -2,6 +2,5 @@ import sys
 import json
 
 if __name__ == "__main__":
-    step_name = sys.argv[1];
     test_results = json.load(open(sys.argv[2], "r"))
-    print(f"::set-output name={step_name}::{test_results}");
+    print(f"::set-output name=orc_test_out::{test_results}");

--- a/.github/orc_test_to_github_actions.py
+++ b/.github/orc_test_to_github_actions.py
@@ -4,4 +4,4 @@ import json
 if __name__ == "__main__":
     step_name = sys.argv[1];
     test_results = json.load(open(sys.argv[2], "r"))
-    print(f"::set-output step_name::{test_results}");
+    print(f"::set-output name={step_name}::{test_results}");

--- a/.github/orc_test_to_github_actions.py
+++ b/.github/orc_test_to_github_actions.py
@@ -2,5 +2,5 @@ import sys
 import json
 
 if __name__ == "__main__":
-    test_results = json.load(open(sys.argv[2], "r"))
+    test_results = json.load(open(sys.argv[1], "r"))
     print(f"::set-output name=orc_test_out::{test_results}");

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,8 +43,7 @@ jobs:
         continue-on-error: true
         run: |
           ./build/Release/orc_test ./test/battery --json_mode > test_out.json
-          cat test_out.json
-          python ${GITHUB_WORKSPACE}/.github/orc_test_to_github_actions.py run-orc_test test_out.json
+          python ${GITHUB_WORKSPACE}/.github/orc_test_to_github_actions.py test_out.json
       - name: 🛠️ orc_test w/ ASan
         id: build-orc_test-asan
         continue-on-error: true
@@ -55,8 +54,7 @@ jobs:
         continue-on-error: true
         run: |
           ./build/Release/orc_test ./test/battery --json_mode > test_out.json
-          cat test_out.json
-          python ${GITHUB_WORKSPACE}/.github/orc_test_to_github_actions.py run-orc_test-asan test_out.json
+          python ${GITHUB_WORKSPACE}/.github/orc_test_to_github_actions.py test_out.json
       - name: 🛠️ orc_test w/ TSan
         id: build-orc_test-tsan
         continue-on-error: true
@@ -67,8 +65,7 @@ jobs:
         continue-on-error: true
         run: |
           ./build/Release/orc_test ./test/battery --json_mode > test_out.json
-          cat test_out.json
-          python ${GITHUB_WORKSPACE}/.github/orc_test_to_github_actions.py run-orc_test-tsan test_out.json
+          python ${GITHUB_WORKSPACE}/.github/orc_test_to_github_actions.py test_out.json
       - name: 🛠️ orc_test w/ UBSan
         id: build-orc_test-ubsan
         continue-on-error: true
@@ -79,8 +76,7 @@ jobs:
         continue-on-error: true
         run: |
           ./build/Release/orc_test ./test/battery --json_mode > test_out.json
-          cat test_out.json
-          python ${GITHUB_WORKSPACE}/.github/orc_test_to_github_actions.py run-orc_test-ubsan test_out.json
+          python ${GITHUB_WORKSPACE}/.github/orc_test_to_github_actions.py test_out.json
       - name: ✏️ github json
         uses: jsdaniell/create-json@1.1.2
         continue-on-error: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,8 +42,8 @@ jobs:
         id: run-orc_test
         continue-on-error: true
         run: |
-          orc_test_results=$(./build/Release/orc_test ./test/battery --json_mode)
-          python ${GITHUB_WORKSPACE}/.github/orc_test_to_github_actions.py run-orc_test "${orc_test_results}"
+          ./build/Release/orc_test ./test/battery --json_mode > test_out.json
+          python ${GITHUB_WORKSPACE}/.github/orc_test_to_github_actions.py run-orc_test test_out.json
       - name: 🛠️ orc_test w/ ASan
         id: build-orc_test-asan
         continue-on-error: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,6 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DORC_BUILD_EXAMPLES=0 -GXcode ..
       - name: ✏️ github json
         uses: jsdaniell/create-json@1.1.2
         continue-on-error: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,6 +43,7 @@ jobs:
         continue-on-error: true
         run: |
           ./build/Release/orc_test ./test/battery --json_mode > test_out.json
+          cat test_out.json
           python ${GITHUB_WORKSPACE}/.github/orc_test_to_github_actions.py run-orc_test test_out.json
       - name: 🛠️ orc_test w/ ASan
         id: build-orc_test-asan
@@ -53,7 +54,9 @@ jobs:
         id: run-orc_test-asan
         continue-on-error: true
         run: |
-          ./build/Release/orc_test ./test/battery GITHUB
+          ./build/Release/orc_test ./test/battery --json_mode > test_out.json
+          cat test_out.json
+          python ${GITHUB_WORKSPACE}/.github/orc_test_to_github_actions.py run-orc_test-asan test_out.json
       - name: 🛠️ orc_test w/ TSan
         id: build-orc_test-tsan
         continue-on-error: true
@@ -63,7 +66,9 @@ jobs:
         id: run-orc_test-tsan
         continue-on-error: true
         run: |
-          ./build/Release/orc_test ./test/battery GITHUB
+          ./build/Release/orc_test ./test/battery --json_mode > test_out.json
+          cat test_out.json
+          python ${GITHUB_WORKSPACE}/.github/orc_test_to_github_actions.py run-orc_test-tsan test_out.json
       - name: 🛠️ orc_test w/ UBSan
         id: build-orc_test-ubsan
         continue-on-error: true
@@ -73,7 +78,9 @@ jobs:
         id: run-orc_test-ubsan
         continue-on-error: true
         run: |
-          ./build/Release/orc_test ./test/battery GITHUB
+          ./build/Release/orc_test ./test/battery --json_mode > test_out.json
+          cat test_out.json
+          python ${GITHUB_WORKSPACE}/.github/orc_test_to_github_actions.py run-orc_test-ubsan test_out.json
       - name: ✏️ github json
         uses: jsdaniell/create-json@1.1.2
         continue-on-error: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,56 +23,6 @@ jobs:
           mkdir build
           cd build
           cmake -DORC_BUILD_EXAMPLES=0 -GXcode ..
-      - name: 🛠️ orc debug
-        id: build-orc-debug
-        continue-on-error: true
-        run: |
-          xcodebuild -project ./build/orc.xcodeproj -scheme orc_orc -configuration Debug -hideShellScriptEnvironment
-      - name: 🛠️ orc release
-        id: build-orc-release
-        continue-on-error: true
-        run: |
-          xcodebuild -project ./build/orc.xcodeproj -scheme orc_orc -configuration Release -hideShellScriptEnvironment
-      - name: 🛠️ orc_test
-        id: build-orc_test
-        continue-on-error: true
-        run: |
-          xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -hideShellScriptEnvironment
-      - name: 🏃 orc_test
-        id: run-orc_test
-        continue-on-error: true
-        run: |
-          /usr/bin/time -l ./build/Release/orc_test ./test/battery
-      - name: 🛠️ orc_test w/ ASan
-        id: build-orc_test-asan
-        continue-on-error: true
-        run: |
-          xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableAddressSanitizer YES -hideShellScriptEnvironment
-      - name: 🏃 orc_test w/ ASan
-        id: run-orc_test-asan
-        continue-on-error: true
-        run: |
-          ./build/Release/orc_test ./test/battery
-      - name: 🛠️ orc_test w/ TSan
-        id: build-orc_test-tsan
-        continue-on-error: true
-        run: |
-          xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableThreadSanitizer YES -hideShellScriptEnvironment
-      - name: 🏃 orc_test w/ TSan
-        id: run-orc_test-tsan
-        continue-on-error: true
-        run: |
-          ./build/Release/orc_test ./test/battery
-      - name: 🛠️ orc_test w/ UBSan
-        id: build-orc_test-ubsan
-        continue-on-error: true
-        run: |
-          xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableUndefinedBehaviorSanitizer YES -hideShellScriptEnvironment
-      - name: 🏃 orc_test w/ UBSan
-        id: run-orc_test-ubsan
-        continue-on-error: true
-        run: |
-          ./build/Release/orc_test ./test/battery
       - name: ✏️ github json
         uses: jsdaniell/create-json@1.1.2
         continue-on-error: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,6 +23,16 @@ jobs:
           mkdir build
           cd build
           cmake -DORC_BUILD_EXAMPLES=0 -GXcode ..
+      - name: 🛠️ orc debug
+        id: build-orc-debug
+        continue-on-error: true
+        run: |
+          xcodebuild -project ./build/orc.xcodeproj -scheme orc_orc -configuration Debug -hideShellScriptEnvironment
+      - name: 🛠️ orc release
+        id: build-orc-release
+        continue-on-error: true
+        run: |
+          xcodebuild -project ./build/orc.xcodeproj -scheme orc_orc -configuration Release -hideShellScriptEnvironment
       - name: 🛠️ orc_test
         id: build-orc_test
         continue-on-error: true
@@ -33,6 +43,36 @@ jobs:
         continue-on-error: true
         run: |
           /usr/bin/time -l ./build/Release/orc_test ./test/battery GITHUB
+      - name: 🛠️ orc_test w/ ASan
+        id: build-orc_test-asan
+        continue-on-error: true
+        run: |
+          xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableAddressSanitizer YES -hideShellScriptEnvironment
+      - name: 🏃 orc_test w/ ASan
+        id: run-orc_test-asan
+        continue-on-error: true
+        run: |
+          ./build/Release/orc_test ./test/battery GITHUB
+      - name: 🛠️ orc_test w/ TSan
+        id: build-orc_test-tsan
+        continue-on-error: true
+        run: |
+          xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableThreadSanitizer YES -hideShellScriptEnvironment
+      - name: 🏃 orc_test w/ TSan
+        id: run-orc_test-tsan
+        continue-on-error: true
+        run: |
+          ./build/Release/orc_test ./test/battery GITHUB
+      - name: 🛠️ orc_test w/ UBSan
+        id: build-orc_test-ubsan
+        continue-on-error: true
+        run: |
+          xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableUndefinedBehaviorSanitizer YES -hideShellScriptEnvironment
+      - name: 🏃 orc_test w/ UBSan
+        id: run-orc_test-ubsan
+        continue-on-error: true
+        run: |
+          ./build/Release/orc_test ./test/battery GITHUB
       - name: ✏️ github json
         uses: jsdaniell/create-json@1.1.2
         continue-on-error: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -q -DORC_BUILD_EXAMPLES=0 -GXcode ..
+          cmake --log-level=WARNING -DORC_BUILD_EXAMPLES=0 -GXcode ..
       - name: 🛠️ orc debug
         id: build-orc-debug
         continue-on-error: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,7 +42,8 @@ jobs:
         id: run-orc_test
         continue-on-error: true
         run: |
-          /usr/bin/time -l ./build/Release/orc_test ./test/battery GITHUB
+          orc_test_results=$(./build/Release/orc_test ./test/battery --json_mode)
+          python ${GITHUB_WORKSPACE}/.github/orc_test_to_github_actions.py run-orc_test "${orc_test_results}"
       - name: 🛠️ orc_test w/ ASan
         id: build-orc_test-asan
         continue-on-error: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,22 +22,22 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DORC_BUILD_EXAMPLES=0 -GXcode ..
+          cmake -q -DORC_BUILD_EXAMPLES=0 -GXcode ..
       - name: 🛠️ orc debug
         id: build-orc-debug
         continue-on-error: true
         run: |
-          xcodebuild -quiet -project ./build/orc.xcodeproj -scheme orc_orc -configuration Debug -hideShellScriptEnvironment
+          xcodebuild -json -project ./build/orc.xcodeproj -scheme orc_orc -configuration Debug -hideShellScriptEnvironment
       - name: 🛠️ orc release
         id: build-orc-release
         continue-on-error: true
         run: |
-          xcodebuild -quiet -project ./build/orc.xcodeproj -scheme orc_orc -configuration Release -hideShellScriptEnvironment
+          xcodebuild -json -project ./build/orc.xcodeproj -scheme orc_orc -configuration Release -hideShellScriptEnvironment
       - name: 🛠️ orc_test
         id: build-orc_test
         continue-on-error: true
         run: |
-          xcodebuild -quiet -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -hideShellScriptEnvironment
+          xcodebuild -json -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -hideShellScriptEnvironment
       - name: 🏃 orc_test
         id: run-orc_test
         continue-on-error: true
@@ -49,7 +49,7 @@ jobs:
         id: build-orc_test-asan
         continue-on-error: true
         run: |
-          xcodebuild -quiet -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableAddressSanitizer YES -hideShellScriptEnvironment
+          xcodebuild -json -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableAddressSanitizer YES -hideShellScriptEnvironment
       - name: 🏃 orc_test w/ ASan
         id: run-orc_test-asan
         continue-on-error: true
@@ -61,7 +61,7 @@ jobs:
         id: build-orc_test-tsan
         continue-on-error: true
         run: |
-          xcodebuild -quiet -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableThreadSanitizer YES -hideShellScriptEnvironment
+          xcodebuild -json -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableThreadSanitizer YES -hideShellScriptEnvironment
       - name: 🏃 orc_test w/ TSan
         id: run-orc_test-tsan
         continue-on-error: true
@@ -73,7 +73,7 @@ jobs:
         id: build-orc_test-ubsan
         continue-on-error: true
         run: |
-          xcodebuild -quiet -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableUndefinedBehaviorSanitizer YES -hideShellScriptEnvironment
+          xcodebuild -json -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableUndefinedBehaviorSanitizer YES -hideShellScriptEnvironment
       - name: 🏃 orc_test w/ UBSan
         id: run-orc_test-ubsan
         continue-on-error: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,17 +27,17 @@ jobs:
         id: build-orc-debug
         continue-on-error: true
         run: |
-          xcodebuild -project ./build/orc.xcodeproj -scheme orc_orc -configuration Debug -hideShellScriptEnvironment
+          xcodebuild -quiet -project ./build/orc.xcodeproj -scheme orc_orc -configuration Debug -hideShellScriptEnvironment
       - name: 🛠️ orc release
         id: build-orc-release
         continue-on-error: true
         run: |
-          xcodebuild -project ./build/orc.xcodeproj -scheme orc_orc -configuration Release -hideShellScriptEnvironment
+          xcodebuild -quiet -project ./build/orc.xcodeproj -scheme orc_orc -configuration Release -hideShellScriptEnvironment
       - name: 🛠️ orc_test
         id: build-orc_test
         continue-on-error: true
         run: |
-          xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -hideShellScriptEnvironment
+          xcodebuild -quiet -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -hideShellScriptEnvironment
       - name: 🏃 orc_test
         id: run-orc_test
         continue-on-error: true
@@ -49,7 +49,7 @@ jobs:
         id: build-orc_test-asan
         continue-on-error: true
         run: |
-          xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableAddressSanitizer YES -hideShellScriptEnvironment
+          xcodebuild -quiet -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableAddressSanitizer YES -hideShellScriptEnvironment
       - name: 🏃 orc_test w/ ASan
         id: run-orc_test-asan
         continue-on-error: true
@@ -61,7 +61,7 @@ jobs:
         id: build-orc_test-tsan
         continue-on-error: true
         run: |
-          xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableThreadSanitizer YES -hideShellScriptEnvironment
+          xcodebuild -quiet -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableThreadSanitizer YES -hideShellScriptEnvironment
       - name: 🏃 orc_test w/ TSan
         id: run-orc_test-tsan
         continue-on-error: true
@@ -73,7 +73,7 @@ jobs:
         id: build-orc_test-ubsan
         continue-on-error: true
         run: |
-          xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableUndefinedBehaviorSanitizer YES -hideShellScriptEnvironment
+          xcodebuild -quiet -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -enableUndefinedBehaviorSanitizer YES -hideShellScriptEnvironment
       - name: 🏃 orc_test w/ UBSan
         id: run-orc_test-ubsan
         continue-on-error: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,6 +22,17 @@ jobs:
         run: |
           mkdir build
           cd build
+          cmake -DORC_BUILD_EXAMPLES=0 -GXcode ..
+      - name: 🛠️ orc_test
+        id: build-orc_test
+        continue-on-error: true
+        run: |
+          xcodebuild -project ./build/orc.xcodeproj -scheme orc_test -configuration Release -hideShellScriptEnvironment
+      - name: 🏃 orc_test
+        id: run-orc_test
+        continue-on-error: true
+        run: |
+          /usr/bin/time -l ./build/Release/orc_test ./test/battery GITHUB
       - name: ✏️ github json
         uses: jsdaniell/create-json@1.1.2
         continue-on-error: true

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -520,10 +520,6 @@ int main(int argc, char** argv) try {
         log::notice("Github Actions output mode enabled");
     }
 
-    log::notice("This is a sample notice", "Title", "filename");
-    log::warning("This is a sample warning");
-    log::error("This is a sample error", "title", "filename");
-
     traverse_directory_tree(battery_path);
 
     return EXIT_SUCCESS;

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -38,7 +38,7 @@ void output(const std::string& type,
             std::optional<std::string> filename = std::nullopt) {
     if (settings()._github_actions_output_mode) {
         std::string result("::");
-        result += output + " ";
+        result += type + " ";
         if (filename) result += "file=" + *filename;
         if (title) result += "title=" + *title;
         result += "::" + message;

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -441,7 +441,7 @@ void run_battery_test(const std::filesystem::path& home) {
 
     auto expected_odrvs = derive_expected_odrvs(home, settings);
     if (expected_odrvs.empty()) {
-        std::cout << "Found no expected ODRVs; expected?\n";
+        log::notice("Found no expected ODRVs for this test");
     }
 
     auto object_files = compile_compilation_units(home, settings, compilation_units);

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -53,9 +53,16 @@ void log(const std::string& type,
          std::optional<std::string> filename = std::nullopt) {
     if (settings()._github_actions_output_mode) {
         std::string result("::");
-        result += type + " line=1";
-        if (filename) result += ",file=" + *filename;
-        if (title) result += ",title=" + *title;
+        result += type + " ";
+        bool first = true;
+        auto append_optional_param = [&](const std::string& key, const auto& value){
+            if (!value) return;
+            if (!first) result += ",";
+            result += key + "=" + *value;
+            first = false;
+        };
+        append_optional_param("file", filename);
+        append_optional_param("title", title);
         result += "::" + message;
         std::cout << result << '\n';
     } else {

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -434,6 +434,8 @@ void run_battery_test(const std::filesystem::path& home) {
         return;
     }
 
+    auto test_name = home.stem().string();
+
     auto compilation_units = derive_compilation_units(home, settings);
     if (compilation_units.empty()) {
         throw std::runtime_error("found no sources to compile");
@@ -441,7 +443,7 @@ void run_battery_test(const std::filesystem::path& home) {
 
     auto expected_odrvs = derive_expected_odrvs(home, settings);
     if (expected_odrvs.empty()) {
-        log::notice("Found no expected ODRVs for this test");
+        log::notice("Found no expected ODRVs for this test", test_name);
     }
 
     auto object_files = compile_compilation_units(home, settings, compilation_units);
@@ -454,7 +456,7 @@ void run_battery_test(const std::filesystem::path& home) {
     toml::table result;
     result.insert("expected", static_cast<toml::int64_t>(expected_odrvs.size()));
     result.insert("reported", static_cast<toml::int64_t>(reports.size()));
-    toml_out().insert(home.stem().string(), std::move(result));
+    toml_out().insert(test_name, std::move(result));
 
     // At this point, the reports.size() should match the expected_odrvs.size()
     bool unexpected_result = false;

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -3,6 +3,7 @@
 #include <exception>
 #include <filesystem>
 #include <iostream>
+#include <sstream>
 #include <unordered_map>
 
 // posix
@@ -22,11 +23,38 @@ namespace {
 /**************************************************************************************************/
 
 struct orc_test_settings {
-    bool _github_actions_output_mode{false};
+    bool _json_mode{false};
 };
 
 auto& settings() {
     static orc_test_settings result;
+    return result;
+}
+
+/**************************************************************************************************/
+
+std::ostream& console() {
+    if (settings()._json_mode) {
+        static std::stringstream s;
+        return s;
+    }
+
+    return std::cout;
+}
+
+std::ostream& console_error() {
+    if (settings()._json_mode) {
+        static std::stringstream s;
+        return s;
+    }
+
+    return std::cerr;
+}
+
+/**************************************************************************************************/
+
+auto& toml_out() {
+    static toml::table result;
     return result;
 }
 
@@ -40,40 +68,32 @@ namespace log {
 
 /**************************************************************************************************/
 
-void set_output(const std::string& name, const std::string& value) {
-    if (!settings()._github_actions_output_mode) return;
-    std::cout << "::set-output name=" << name << "::" << value << '\n';
-}
-
-/**************************************************************************************************/
-
 void log(const std::string& type,
          const std::string& message,
          std::optional<std::string> title = std::nullopt,
          std::optional<std::string> filename = std::nullopt) {
-    if (settings()._github_actions_output_mode) {
-        std::string result("::");
-        result += type + " ";
-        bool first = true;
-        auto append_optional_param = [&](const std::string& key, const auto& value){
-            if (!value) return;
-            if (!first) result += ",";
-            result += key + "=" + *value;
-            first = false;
-        };
-        append_optional_param("file", filename);
-        append_optional_param("title", title);
-        result += "::" + message;
-        std::cout << result << '\n';
+    if (settings()._json_mode) {
+        toml::table result;
+        result.insert("type", type);
+        result.insert("message", message);
+        if (title) result.insert("title", *title);
+        if (filename) result.insert("filename", *filename);
+        if (auto* array = toml_out()["log"].as_array()) {
+            array->push_back(result);
+        } else {
+            toml::array new_log;
+            new_log.push_back(std::move(result));
+            toml_out().insert("log", std::move(new_log));
+        }
     } else {
         if (title) {
-            std::cout << *title << ": ";
+            console() << *title << ": ";
         }
-        std::cout << message;
+        console() << message;
         if (filename) {
-            std::cout << " (" << *filename << ")";
+            console() << " (" << *filename << ")";
         }
-        std::cout << '\n';
+        console() << '\n';
     }
 }
 
@@ -88,16 +108,16 @@ void notice(const std::string& message,
 /**************************************************************************************************/
 
 void warning(const std::string& message,
-            std::optional<std::string> title = std::nullopt,
-            std::optional<std::string> filename = std::nullopt) {
+             std::optional<std::string> title = std::nullopt,
+             std::optional<std::string> filename = std::nullopt) {
     log("warning", message, title, filename);
 }
 
 /**************************************************************************************************/
 
 void error(const std::string& message,
-            std::optional<std::string> title = std::nullopt,
-            std::optional<std::string> filename = std::nullopt) {
+           std::optional<std::string> title = std::nullopt,
+           std::optional<std::string> filename = std::nullopt) {
     log("error", message, title, filename);
 }
 
@@ -298,11 +318,11 @@ std::vector<std::filesystem::path> compile_compilation_units(const std::filesyst
     std::vector<std::filesystem::path> object_files;
     const bool preserve_object_files =
         settings["orc_test_flags"]["preserve_object_files"].value_or(false);
-    std::cout << "Compiling " << units.size() << " source file(s):\n";
+    console() << "Compiling " << units.size() << " source file(s):\n";
     for (auto& unit : units) {
         auto temp_path = object_file_path(home, unit);
         if (preserve_object_files) {
-            std::cout << temp_path << '\n';
+            console() << temp_path << '\n';
         } else {
             unit._path = temp_path;
         }
@@ -312,14 +332,14 @@ std::vector<std::filesystem::path> compile_compilation_units(const std::filesyst
         }
         command += " -g -c " + unit._src.string() + " -o " + temp_path.string();
         // Save this for debugging purposes.
-        // std::cout << command << '\n';
+        // console() << command << '\n';
         std::string result = exec(command.c_str());
         if (!result.empty()) {
-            std::cout << result;
+            console() << result;
             throw std::runtime_error("unexpected compilation failure");
         }
         object_files.emplace_back(std::move(temp_path));
-        std::cout << "    " << unit._src.filename() << " -> " << object_files.back().filename() << '\n';
+        console() << "    " << unit._src.filename() << " -> " << object_files.back().filename() << '\n';
     }
     return object_files;
 }
@@ -385,7 +405,7 @@ void run_battery_test(const std::filesystem::path& home) {
     static bool first_s = false;
 
     if (!first_s) {
-        std::cout << '\n';
+        console() << '\n';
     } else {
         first_s = false;
     }
@@ -395,17 +415,17 @@ void run_battery_test(const std::filesystem::path& home) {
     assume(is_regular_file(tomlpath), "\"" + tomlpath.string() + "\" is not a regular file");
     toml::table settings;
 
-    std::cout << "-=-=- Test: " << home << "\n";
+    console() << "-=-=- Test: " << home << "\n";
 
     try {
         settings = toml::parse_file(tomlpath.string());
     } catch (const toml::parse_error& error) {
-        std::cerr << error << '\n';
+        console_error() << error << '\n';
         throw std::runtime_error("settings file parsing error");
     }
 
     // Save this for debugging purposes.
-    // std::cerr << toml::json_formatter{settings} << '\n';
+    // console_error() << toml::json_formatter{settings} << '\n';
 
     const bool skip_test = settings["orc_test_flags"]["disable"].value_or(false);
 
@@ -429,10 +449,12 @@ void run_battery_test(const std::filesystem::path& home) {
     orc_reset();
     auto reports = orc_process(object_files);
 
-    std::cout << "ODRVs expected: " << expected_odrvs.size() << "; reported: " << reports.size() << '\n';
+    console() << "ODRVs expected: " << expected_odrvs.size() << "; reported: " << reports.size() << '\n';
 
-    log::set_output(home.stem().string() + ".expected", std::to_string(expected_odrvs.size()));
-    log::set_output(home.stem().string() + ".reported", std::to_string(reports.size()));
+    toml::table result;
+    result.insert("expected", static_cast<toml::int64_t>(expected_odrvs.size()));
+    result.insert("reported", static_cast<toml::int64_t>(reports.size()));
+    toml_out().insert(home.stem().string(), std::move(result));
 
     // At this point, the reports.size() should match the expected_odrvs.size()
     bool unexpected_result = false;
@@ -451,22 +473,22 @@ void run_battery_test(const std::filesystem::path& home) {
                 break;
             }
 
-            std::cout << "    Found expected ODRV: " << report.category() << "\n";
+            console() << "    Found expected ODRV: " << report.category() << "\n";
         }
     }
 
     if (unexpected_result) {
-        std::cerr << "Reported ODRV(s):\n";
+        console_error() << "Reported ODRV(s):\n";
 
         // If there's an error in the test, dump what we've found to assist debugging.
         for (const auto& report : reports) {
-            std::cout << report << '\n';
+            console() << report << '\n';
         }
 
-        std::cerr << "Expected ODRV(s):\n";
+        console_error() << "Expected ODRV(s):\n";
         std::size_t count{0};
         for (const auto& expected : expected_odrvs) {
-            std::cout << ++count << ":\n" << expected << '\n';
+            console() << ++count << ":\n" << expected << '\n';
         }
 
         throw std::runtime_error("ODRV count mismatch");
@@ -490,7 +512,7 @@ void traverse_directory_tree(std::filesystem::path& directory) {
                 traverse_directory_tree(path);
             }
         } catch (...) {
-            std::cerr << "\nIn battery " << entry.path() << ":";
+            console_error() << "\nIn battery " << entry.path() << ":";
             throw;
         }
     }
@@ -504,7 +526,7 @@ void traverse_directory_tree(std::filesystem::path& directory) {
 
 int main(int argc, char** argv) try {
     if (argc < 2) {
-        std::cerr << "Usage: " << argv[0] << " /path/to/test/battery/\n";
+        console_error() << "Usage: " << argv[0] << " /path/to/test/battery/\n";
         throw std::runtime_error("no path to test battery given");
     }
 
@@ -514,13 +536,13 @@ int main(int argc, char** argv) try {
         throw std::runtime_error("test battery path is missing or not a directory");
     }
 
-    settings()._github_actions_output_mode = argc > 2 && std::string(argv[2]) == "GITHUB";
-
-    if (settings()._github_actions_output_mode) {
-        log::notice("Github Actions output mode enabled");
-    }
+    settings()._json_mode = argc > 2 && std::string(argv[2]) == "--json_mode";
 
     traverse_directory_tree(battery_path);
+
+    if (settings()._json_mode) {
+        std::cout << toml::json_formatter{ toml_out() } << '\n';
+    }
 
     return EXIT_SUCCESS;
 } catch (const std::exception& error) {

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -78,12 +78,12 @@ void log(const std::string& type,
         result.insert("message", message);
         if (title) result.insert("title", *title);
         if (filename) result.insert("filename", *filename);
-        if (auto* array = toml_out()["log"].as_array()) {
+        if (auto* array = toml_out()["_orc_test_log"].as_array()) {
             array->push_back(result);
         } else {
             toml::array new_log;
             new_log.push_back(std::move(result));
-            toml_out().insert("log", std::move(new_log));
+            toml_out().insert("_orc_test_log", std::move(new_log));
         }
     } else {
         if (title) {


### PR DESCRIPTION
It turns out GitHub Actions is watching `stdout` for special output tokens from any source, and if it finds them, it will incorporate that output into the state of the GHA system. This gives us the ability to produce output by `orc_test` that can then be captured by GHA and used to produce the Job Summary at the end of the main Actions workflow.

This PR modifies `orc_test` to accept an additional `--json_mode` parameter that, when present, will output a handful of logging entries using JSON. Without the flag, the output is more human readable (but won't get captured.) The github action will then post-process that JSON into github-actions-specific output that can be shared across steps in the GHA workflow.

The PR also adds new updates to the job summary generator script that includes the output from `orc_test` in the summary, giving us an at-a-glance review of the tests being run and their results.