### PR TITLE
Stable ORDV Reporting

### DIFF
--- a/include/orc/dwarf_structs.hpp
+++ b/include/orc/dwarf_structs.hpp
@@ -101,6 +101,8 @@ struct attribute_value {
         return *_die;
     }
 
+    std::size_t hash() const;
+
     auto type() const { return _type; }
     bool has(enum type t) const { return has_type(type(), t); }
     bool has_none() const { return has(type::none); }
@@ -208,7 +210,8 @@ struct die {
     // here, please consider alignment issues.
     object_ancestry _ancestry;
     pool_string _path;
-    attribute* _attributes;
+    attribute* _attributes{nullptr};
+    die* _next_die{nullptr};
     std::size_t _attributes_size{0};
     std::size_t _hash{0};
     std::uint32_t _debug_info_offset{0}; // relative from top of __debug_info
@@ -216,6 +219,7 @@ struct die {
     arch _arch{arch::unknown};
     bool _has_children{false};
     bool _type_resolved{false};
+    bool _conflict{false};
 
     auto begin() { return _attributes; }
     auto begin() const { return _attributes; }

--- a/include/orc/orc.hpp
+++ b/include/orc/orc.hpp
@@ -22,7 +22,6 @@ struct odrv_report {
     dw::at _name;
 
     std::string category() const;
-    pool_string attribute_string(dw::at name) const;
 };
 
 std::ostream& operator<<(std::ostream& s, const odrv_report& x);

--- a/include/orc/orc.hpp
+++ b/include/orc/orc.hpp
@@ -18,7 +18,7 @@
 
 struct odrv_report {
     std::string_view _symbol;
-    const die* _die{nullptr};
+    const die* _list_head{nullptr};
     dw::at _name;
 
     std::string category() const;

--- a/include/orc/orc.hpp
+++ b/include/orc/orc.hpp
@@ -18,8 +18,7 @@
 
 struct odrv_report {
     std::string_view _symbol;
-    die _a;
-    die _b;
+    const die* _die{nullptr};
     dw::at _name;
 
     std::string category() const;

--- a/include/orc/string_pool.hpp
+++ b/include/orc/string_pool.hpp
@@ -41,8 +41,8 @@ pool_string empool(std::string_view src);
     and out, just in case the processor doesn't like un-aligned reads.
 */
 struct pool_string {
-    pool_string() {}
-    ~pool_string() {}
+    pool_string() = default;
+    ~pool_string() = default;
 
     bool empty() const { return _data == nullptr; }
 

--- a/src/dwarf_structs.cpp
+++ b/src/dwarf_structs.cpp
@@ -43,10 +43,10 @@ void attribute::read(freader& s) {
 
 std::size_t attribute_value::hash() const {
     // order here matches operator==
-    if (has_string()) return hash_combine(0, string().hash());
-    else if (has_uint()) return hash_combine(0, uint());
-    else if (has_sint()) return hash_combine(0, sint());
-    return hash_combine(0, type());
+    if (has_string()) return string().hash();
+    else if (has_uint()) return uint();
+    else if (has_sint()) return sint();
+    return static_cast<std::size_t>(type());
 }
 
 /**************************************************************************************************/

--- a/src/dwarf_structs.cpp
+++ b/src/dwarf_structs.cpp
@@ -41,6 +41,16 @@ void attribute::read(freader& s) {
 
 /**************************************************************************************************/
 
+std::size_t attribute_value::hash() const {
+    // order here matches operator==
+    if (has_string()) return hash_combine(0, string().hash());
+    else if (has_uint()) return hash_combine(0, uint());
+    else if (has_sint()) return hash_combine(0, sint());
+    return hash_combine(0, type());
+}
+
+/**************************************************************************************************/
+
 std::ostream& operator<<(std::ostream& s, const attribute_value& x) {
     if (x.type() == attribute_value::type::none) return s << "<none>";
     if (x.type() == attribute_value::type::passover) return s << "<unhandled>";

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -278,7 +278,7 @@ bool odrv_report_match(const expected_odrv& odrv, const odrv_report& report) {
 
     const std::string& linkage_name = odrv.linkage_name();
     if (!linkage_name.empty()) {
-        const pool_string report_linkage_name = report._die->attribute_string(dw::at::linkage_name);
+        const pool_string report_linkage_name = report._list_head->attribute_string(dw::at::linkage_name);
         if (linkage_name != report_linkage_name.view())
             return false;
     }

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -278,7 +278,7 @@ bool odrv_report_match(const expected_odrv& odrv, const odrv_report& report) {
 
     const std::string& linkage_name = odrv.linkage_name();
     if (!linkage_name.empty()) {
-        const pool_string report_linkage_name = report.attribute_string(dw::at::linkage_name);
+        const pool_string report_linkage_name = report._die->attribute_string(dw::at::linkage_name);
         if (linkage_name != report_linkage_name.view())
             return false;
     }


### PR DESCRIPTION
Fixes #26.

This PR leverages the conflict map we are already building in `register_dies`. Each `die` is given a pointer that we'll use to construct a series of linked lists. Each entry in the conflict map is the head of one of these lists, and pointers to other `die`s are appended to each list according to the symbol each `die` represents.

A linked list of `die`s will all represent the same symbol. Each unique symbol will have its own unique linked list (even if it's size is one.)

At the time a `die` is appended to its respective linked list, it is compared against the head node to determine if there is a conflict. If there is, the entire linked list is "poisoned" as having a conflict (this is denoted with a flag at the head node.)

Once the `register_dies` phase has completed, we can report on the ODRVs by looking at each poisoned linked list, and therein contain all the `die`s that contribute to the conflict. This way, regardless of the order in which the `die`s are processed, we should get a consistent output of ODR violations.