### PR TITLE
Mildly optimize die memory

### DIFF
--- a/include/orc/dwarf_structs.hpp
+++ b/include/orc/dwarf_structs.hpp
@@ -226,9 +226,9 @@ struct die {
     pool_string _path;
     attribute* _attributes{nullptr};
     die* _next_die{nullptr};
-    std::size_t _attributes_size{0};
     std::size_t _hash{0};
     std::uint32_t _debug_info_offset{0}; // relative from top of __debug_info
+    std::uint32_t _attributes_size{0};
     dw::tag _tag{dw::tag::none};
     arch _arch{arch::unknown};
     bool _has_children{false};

--- a/include/orc/dwarf_structs.hpp
+++ b/include/orc/dwarf_structs.hpp
@@ -228,8 +228,8 @@ struct die {
     die* _next_die{nullptr};
     std::size_t _hash{0};
     std::uint32_t _debug_info_offset{0}; // relative from top of __debug_info
-    std::uint32_t _attributes_size{0};
     dw::tag _tag{dw::tag::none};
+    std::uint8_t _attributes_size{0};
     arch _arch{arch::unknown};
     bool _has_children{false};
     bool _type_resolved{false};

--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -934,6 +934,7 @@ die dwarf::implementation::abbreviation_to_die(std::size_t die_address, std::uin
 
     result._tag = a._tag;
     result._has_children = a._has_children;
+    assert(a._attributes.size() < 256); // we've never seen anything even close to 255, but check to be sure
     result._attributes_size = a._attributes.size();
     result._attributes = alloc_attributes(result._attributes_size);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

By reducing the `_attributes_size` property of the die from `size_t` to `uint8_t` brings the overall die size down from 104 to 96 bytes. There isn't any practical impact to the max number of attributes, and testing confirms the reordering is immaterial. Peak memory footprint reduces from 61.5 to 59.3 GB. 

Note that - because of packing - there's room in the die now for 3 more bytes before it jumps back up to 104 bytes.
