### PR TITLE
Fatal Attribute Hashing

### DIFF
--- a/_orc-config
+++ b/_orc-config
@@ -48,7 +48,7 @@ print_symbol_paths = false
 #
 # The default value is `'warning'`.
 
-log_level = 'warning'
+log_level = 'info'
 
 # Output a die-count-based progress update throughout the session.
 #

--- a/_orc-config
+++ b/_orc-config
@@ -48,7 +48,7 @@ print_symbol_paths = false
 #
 # The default value is `'warning'`.
 
-log_level = 'info'
+log_level = 'warning'
 
 # Output a die-count-based progress update throughout the session.
 #

--- a/include/orc/dwarf.hpp
+++ b/include/orc/dwarf.hpp
@@ -18,9 +18,8 @@
 struct dwarf {
     dwarf(object_ancestry&& ancestry,
           freader&& s,
-          bool needs_byteswap,
-          arch arch,
-          register_dies_callback callback);
+          file_details&& details,
+          register_dies_callback&& callback);
 
     void register_section(std::string name, std::size_t offset, std::size_t size);
 

--- a/include/orc/dwarf.hpp
+++ b/include/orc/dwarf.hpp
@@ -18,7 +18,7 @@
 using die_pair = std::tuple<die, attribute_sequence>;
 
 struct dwarf {
-    dwarf(object_ancestry&& ancestry,
+    dwarf(const object_ancestry& ancestry,
           freader&& s,
           file_details&& details,
           register_dies_callback&& callback);

--- a/include/orc/dwarf.hpp
+++ b/include/orc/dwarf.hpp
@@ -15,6 +15,8 @@
 
 /**************************************************************************************************/
 
+using die_pair = std::tuple<die, attribute_sequence>;
+
 struct dwarf {
     dwarf(object_ancestry&& ancestry,
           freader&& s,
@@ -25,7 +27,7 @@ struct dwarf {
 
     void process_all_dies();
 
-    std::tuple<die, attribute_sequence> fetch_one_die(std::size_t debug_info_offset);
+    die_pair fetch_one_die(std::size_t debug_info_offset);
 
 private:
     struct implementation;

--- a/include/orc/dwarf.hpp
+++ b/include/orc/dwarf.hpp
@@ -18,7 +18,7 @@
 using die_pair = std::tuple<die, attribute_sequence>;
 
 struct dwarf {
-    dwarf(const object_ancestry& ancestry,
+    dwarf(std::uint32_t ofd_index,
           freader&& s,
           file_details&& details,
           register_dies_callback&& callback);

--- a/include/orc/dwarf.hpp
+++ b/include/orc/dwarf.hpp
@@ -17,13 +17,16 @@
 
 struct dwarf {
     dwarf(object_ancestry&& ancestry,
-          freader& s,
-          const file_details& details,
-          callbacks callbacks);
+          freader&& s,
+          bool needs_byteswap,
+          arch arch,
+          register_dies_callback callback);
 
     void register_section(std::string name, std::size_t offset, std::size_t size);
 
-    void process();
+    void process_all_dies();
+
+    std::tuple<die, attribute_sequence> fetch_one_die(std::size_t debug_info_offset);
 
 private:
     struct implementation;

--- a/include/orc/dwarf_structs.hpp
+++ b/include/orc/dwarf_structs.hpp
@@ -214,19 +214,19 @@ struct attribute_sequence {
         return *iterator;
     }
 
-    auto hash(dw::at name) const {
+    std::size_t hash(dw::at name) const {
         return get(name)._value.hash();
     }
 
-    auto uint(dw::at name) const {
+    std::uint64_t uint(dw::at name) const {
         return get(name).uint();
     }
 
-    auto string(dw::at name) const {
+    pool_string string(dw::at name) const {
         return get(name).string();
     }
 
-    auto reference(dw::at name) const {
+    std::uint64_t reference(dw::at name) const {
         return get(name).reference();
     }
 
@@ -234,7 +234,7 @@ struct attribute_sequence {
         _attributes.push_back(x);
     }
 
-    auto empty() const { return _attributes.empty(); }
+    bool empty() const { return _attributes.empty(); }
 
     auto begin() { return _attributes.begin(); }
     auto begin() const { return _attributes.begin(); }

--- a/include/orc/dwarf_structs.hpp
+++ b/include/orc/dwarf_structs.hpp
@@ -210,6 +210,10 @@ struct attribute_sequence {
         return *iterator;
     }
 
+    auto hash(dw::at name) const {
+        return get(name)._value.hash();
+    }
+
     auto uint(dw::at name) const {
         return get(name).uint();
     }

--- a/include/orc/dwarf_structs.hpp
+++ b/include/orc/dwarf_structs.hpp
@@ -149,7 +149,7 @@ struct attribute {
     dw::form _form{0};
     attribute_value _value;
 
-    void read(freader& s); // definition in dwarf.cpp
+    void read(freader& s);
 
     auto has(enum attribute_value::type t) const { return _value.has(t); }
 
@@ -171,10 +171,10 @@ std::ostream& operator<<(std::ostream& s, const attribute& x);
 /**************************************************************************************************/
 // I'm not a fan of this name.
 struct attribute_sequence {
-    using attributes = std::vector<attribute>;
-    using value_type = typename attributes::value_type;
-    using iterator = typename attributes::iterator;
-    using const_iterator = typename attributes::const_iterator;
+    using attributes_type = std::vector<attribute>;
+    using value_type = typename attributes_type::value_type;
+    using iterator = typename attributes_type::iterator;
+    using const_iterator = typename attributes_type::const_iterator;
 
     bool has(dw::at name) const {
         auto [valid, iterator] = find(name);
@@ -252,7 +252,7 @@ private:
         return std::make_tuple(result != _attributes.end(), result);
     }
 
-    std::vector<attribute> _attributes;
+    attributes_type _attributes;
 };
 
 std::ostream& operator<<(std::ostream& s, const attribute_sequence& x);
@@ -319,7 +319,6 @@ struct die {
     std::size_t _fatal_attribute_hash{0};
     std::uint32_t _debug_info_offset{0}; // relative from top of __debug_info
     dw::tag _tag{dw::tag::none};
-    std::uint8_t _attributes_size{0};
     arch _arch{arch::unknown};
     bool _has_children{false};
     bool _conflict{false};

--- a/include/orc/dwarf_structs.hpp
+++ b/include/orc/dwarf_structs.hpp
@@ -176,6 +176,10 @@ struct attribute_sequence {
     using iterator = typename attributes_type::iterator;
     using const_iterator = typename attributes_type::const_iterator;
 
+    void reserve(std::size_t size) {
+        _attributes.reserve(size);
+    }
+
     bool has(dw::at name) const {
         auto [valid, iterator] = find(name);
         return valid;
@@ -347,6 +351,21 @@ template <class Container, class T>
 bool sorted_has(const Container& c, const T& x) {
     auto found = std::lower_bound(c.begin(), c.end(), x);
     return found != c.end() && *found == x;
+}
+
+/**************************************************************************************************/
+// Quick and dirty type to print an integer value as a padded, fixed-width hex value.
+// e.g., std::cout << hex_print(my_int) << '\n';
+struct hex_print {
+    explicit hex_print(std::size_t x) : _x{x} {}
+    std::size_t _x;
+};
+
+inline std::ostream& operator<<(std::ostream& s, const hex_print& x) {
+    s << "0x";
+    s.width(8);
+    s.fill('0');
+    return s << std::hex << x._x << std::dec;
 }
 
 /**************************************************************************************************/

--- a/include/orc/dwarf_structs.hpp
+++ b/include/orc/dwarf_structs.hpp
@@ -324,9 +324,9 @@ struct die {
     // here, please consider alignment issues.
     pool_string _path;
     die* _next_die{nullptr};
-    const object_ancestry* _ancestry{nullptr}; // points to the obj_registry in macho.cpp
     std::size_t _hash{0};
     std::size_t _fatal_attribute_hash{0};
+    std::uint32_t _ofd_index{0}; // object file descriptor index
     std::uint32_t _debug_info_offset{0}; // relative from top of __debug_info
     dw::tag _tag{dw::tag::none};
     arch _arch{arch::unknown};
@@ -334,13 +334,7 @@ struct die {
     bool _conflict{false};
     bool _skippable{false};
 
-    bool operator<(const die& rhs) const {
-        if (_path.view() < rhs._path.view())
-            return true;
-        if (_path.view() > rhs._path.view())
-            return false;
-        return _ancestry < rhs._ancestry;
-    }
+    friend bool operator<(const die& x, const die& y);
 };
 
 std::ostream& operator<<(std::ostream& s, const die& x);

--- a/include/orc/dwarf_structs.hpp
+++ b/include/orc/dwarf_structs.hpp
@@ -322,7 +322,7 @@ struct die {
     arch _arch{arch::unknown};
     bool _has_children{false};
     bool _conflict{false};
-    bool _should_skip{false};
+    bool _skippable{false};
 
     bool operator<(const die& rhs) const {
         if (_path.view() < rhs._path.view())

--- a/include/orc/dwarf_structs.hpp
+++ b/include/orc/dwarf_structs.hpp
@@ -282,7 +282,13 @@ struct object_ancestry {
 
     auto begin() const { return _ancestors.begin(); }
     auto end() const { return begin() + _count; }
+
     auto& back() {
+        assert(_count);
+        return _ancestors[_count];
+    }
+
+    const auto& back() const {
         assert(_count);
         return _ancestors[_count];
     }
@@ -316,9 +322,9 @@ struct die {
     // Because the quantity of these created at runtime can beon the order of millions of instances,
     // these are ordered for optimal alignment. If you change the ordering, or add/remove items
     // here, please consider alignment issues.
-    object_ancestry _ancestry;
     pool_string _path;
     die* _next_die{nullptr};
+    const object_ancestry* _ancestry{nullptr}; // points to the obj_registry in macho.cpp
     std::size_t _hash{0};
     std::size_t _fatal_attribute_hash{0};
     std::uint32_t _debug_info_offset{0}; // relative from top of __debug_info

--- a/include/orc/hash.hpp
+++ b/include/orc/hash.hpp
@@ -1,0 +1,73 @@
+// Copyright 2022 Adobe
+// All Rights Reserved.
+//
+// NOTICE: Adobe permits you to use, modify, and distribute this file in accordance with the terms
+// of the Adobe license agreement accompanying it.
+
+#pragma once
+
+// stdc++
+#include <iostream>
+
+/**************************************************************************************************/
+
+namespace orc {
+
+/**************************************************************************************************/
+// This is an extension of the famous boost hash_combine routine, extending it to take a variable
+// number of input items to hash and then combine together. It's a pack compression of the following
+// kind of expansion:
+//
+// template <class N0, class N1, ..., class NM>
+// inline std::size_t hash_combine(std::size_t seed,
+//                                 const N0& n0,
+//                                 const N1& n1,
+//                                 ...
+//                                 const NM& nm) {
+//     auto h0 = seed ^ std::hash<N0>{}(n0) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+//     auto h1 = h0   ^ std::hash<N1>{}(n1) + 0x9e3779b9 + (h0   << 6) + (h0   >> 2);
+//     ...
+//     auto hm_1 = ... // the hash from the (NM-1)-th step
+//     auto hm = hm_1 ^ std::hash<NM>{}(nm) + 0x9e3779b9 + (hm_1 << 6) + (hm_1 >> 2);
+//     return hm;
+// }
+
+template <class T>
+inline std::size_t hash_combine(std::size_t seed, const T& x) {
+    // This is the terminating hash_combine call when there's only one item left to hash into the
+    // seed. It also serves as the combiner the other routine variant uses to generate its new
+    // seed.
+    return seed ^ std::hash<T>{}(x) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+template <class T, class... Args>
+inline std::size_t hash_combine(std::size_t seed, const T& x, Args&&... args) {
+    // This routine reduces the argument count by 1 by hashing `x` into the seed, and calling
+    // hash_combine on the remaining arguments and the new seed. Eventually Args will disintegrate
+    // into a single parameter, at which point the compiler will call the above routine, not this
+    // one (which has more than two args), and the compile-time recursion will stop.
+    return hash_combine(hash_combine(seed, x), std::forward<Args>(args)...);
+}
+
+/**************************************************************************************************/
+// An implementation of MurmurHash3 from SMHasher on GitHub, since modified and used here.
+struct murmur_hash {
+    static_assert(sizeof(std::size_t) == sizeof(std::uint64_t));
+    std::size_t hi{0};
+    std::size_t lo{0};
+};
+
+murmur_hash murmur3(const void* key, int len, uint32_t seed = 0);
+
+// 64-bit combination of the 128 bit murmur hash. May need to punt on this one if it collides too
+// much, but 64 bits is easier to handle than 128.
+inline std::size_t murmur3_64(const void* key, int len, uint32_t seed = 0) {
+    auto result = murmur3(key, len, seed);
+    return hash_combine(result.hi, result.lo);
+}
+
+/**************************************************************************************************/
+
+} // namespace orc
+
+/**************************************************************************************************/

--- a/include/orc/macho.hpp
+++ b/include/orc/macho.hpp
@@ -21,3 +21,7 @@ void read_macho(object_ancestry&& ancestry,
                 callbacks callbacks);
 
 /**************************************************************************************************/
+
+struct dwarf dwarf_from_macho(object_ancestry&& ancestry, register_dies_callback&& callback);
+
+/**************************************************************************************************/

--- a/include/orc/macho.hpp
+++ b/include/orc/macho.hpp
@@ -22,6 +22,6 @@ void read_macho(object_ancestry&& ancestry,
 
 /**************************************************************************************************/
 
-struct dwarf dwarf_from_macho(object_ancestry&& ancestry, register_dies_callback&& callback);
+struct dwarf dwarf_from_macho(const object_ancestry& ancestry, register_dies_callback&& callback);
 
 /**************************************************************************************************/

--- a/include/orc/object_file_registry.hpp
+++ b/include/orc/object_file_registry.hpp
@@ -6,22 +6,29 @@
 
 #pragma once
 
-// stdc++
-#include <iostream>
-
 // application
+#include "orc/dwarf_structs.hpp"
 #include "orc/parse_file.hpp"
 
 /**************************************************************************************************/
 
-void read_macho(object_ancestry&& ancestry,
-                freader s,
-                std::istream::pos_type end_pos,
-                file_details details,
-                callbacks callbacks);
+struct object_file_descriptor {
+    object_ancestry _ancestry;
+    file_details _details;
+};
 
 /**************************************************************************************************/
 
-struct dwarf dwarf_from_macho(std::uint32_t ofd_index, register_dies_callback&& callback);
+std::size_t object_file_register(object_ancestry&& ancestry, file_details&& details);
+
+const object_file_descriptor& object_file_fetch(std::size_t index);
+
+inline const object_ancestry& object_file_ancestry(std::size_t index) {
+    return object_file_fetch(index)._ancestry;
+}
+
+inline const file_details& object_file_details(std::size_t index) {
+    return object_file_fetch(index)._details;
+}
 
 /**************************************************************************************************/

--- a/include/orc/orc.hpp
+++ b/include/orc/orc.hpp
@@ -10,6 +10,7 @@
 #include <filesystem>
 #include <unordered_map>
 #include <vector>
+#include <map>
 
 // application
 #include <orc/dwarf_structs.hpp>
@@ -17,11 +18,17 @@
 /**************************************************************************************************/
 
 struct odrv_report {
+    odrv_report(std::string_view symbol, const die* list_head) : _symbol(symbol), _list_head(list_head) {}
+
     std::string_view _symbol;
     const die* _list_head{nullptr};
-    dw::at _name;
 
     std::string category() const;
+
+    const auto& conflict_map() const { return _conflict_map; }
+
+private:
+    mutable std::map<std::size_t, const die*> _conflict_map;
 };
 
 std::ostream& operator<<(std::ostream& s, const odrv_report& x);

--- a/include/orc/orc.hpp
+++ b/include/orc/orc.hpp
@@ -18,17 +18,23 @@
 /**************************************************************************************************/
 
 struct odrv_report {
-    odrv_report(std::string_view symbol, const die* list_head) : _symbol(symbol), _list_head(list_head) {}
-
-    std::string_view _symbol;
-    const die* _list_head{nullptr};
+    odrv_report(std::string_view symbol, const die* list_head);
 
     std::string category() const;
 
+    struct conflict_details {
+        const die* _die{nullptr};
+        attribute_sequence _attributes;
+    };
+
     const auto& conflict_map() const { return _conflict_map; }
 
+    std::string_view _symbol;
+
 private:
-    mutable std::map<std::size_t, const die*> _conflict_map;
+    const die* _list_head{nullptr};
+    mutable std::map<std::size_t, conflict_details> _conflict_map;
+    dw::at _name{dw::at::none};
 };
 
 std::ostream& operator<<(std::ostream& s, const odrv_report& x);

--- a/include/orc/parse_file.hpp
+++ b/include/orc/parse_file.hpp
@@ -245,7 +245,6 @@ using empool_callback = std::function<pool_string(std::string_view)>;
 struct callbacks {
     register_dies_callback _register_die;
     do_work_callback _do_work;
-    empool_callback _empool;
 };
 
 void parse_file(std::string_view object_name,

--- a/include/orc/settings.hpp
+++ b/include/orc/settings.hpp
@@ -46,7 +46,7 @@ struct globals {
 
     std::atomic_size_t _object_file_count{0};
     std::atomic_size_t _odrv_count{0};
-    std::atomic_size_t _die_registered_count{0};
+    std::atomic_size_t _unique_symbol_count{0};
     std::atomic_size_t _die_processed_count{0};
     std::atomic_size_t _die_analyzed_count{0};
     std::ofstream _fp;

--- a/include/orc/settings.hpp
+++ b/include/orc/settings.hpp
@@ -47,9 +47,13 @@ struct globals {
     std::atomic_size_t _object_file_count{0};
     std::atomic_size_t _odrv_count{0};
     std::atomic_size_t _unique_symbol_count{0};
+    std::atomic_size_t _unique_symbol_die_count{0};
     std::atomic_size_t _die_processed_count{0};
     std::atomic_size_t _die_analyzed_count{0};
     std::ofstream _fp;
+
+private:
+    globals() = default;
 };
 
 /**************************************************************************************************/

--- a/include/orc/string_pool.hpp
+++ b/include/orc/string_pool.hpp
@@ -63,7 +63,7 @@ struct pool_string {
         return std::filesystem::path(view()); 
     }
 
-    size_t hash() const {
+    std::size_t hash() const {
         if (!_data) return 0;
         return get_hash(_data);
     }

--- a/include/orc/string_pool.hpp
+++ b/include/orc/string_pool.hpp
@@ -46,6 +46,8 @@ struct pool_string {
 
     bool empty() const { return _data == nullptr; }
 
+    explicit operator bool() const { return empty(); }
+
     std::string_view view() const {
         // a string_view is empty iff _data is a nullptr
         if (!_data) return default_view;

--- a/include/orc/string_pool.hpp
+++ b/include/orc/string_pool.hpp
@@ -51,8 +51,7 @@ struct pool_string {
     std::string_view view() const {
         // a string_view is empty iff _data is a nullptr
         if (!_data) return default_view;
-        std::uint32_t size = get_size(_data);
-        return std::string_view(_data, size);
+        return std::string_view(_data, get_size(_data));
     }
     
     std::string allocate_string() const { 
@@ -66,6 +65,11 @@ struct pool_string {
     std::size_t hash() const {
         if (!_data) return 0;
         return get_hash(_data);
+    }
+
+    std::size_t size() const {
+        if (!_data) return 0;
+        return get_size(_data);
     }
 
     friend inline bool operator==(const pool_string& x, const pool_string& y) {

--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -192,7 +192,7 @@ struct file_name {
 std::size_t die_hash(const die& d, const attribute_sequence& attributes) {
     bool is_declaration =
         attributes.has_uint(dw::at::declaration) && attributes.uint(dw::at::declaration) == 1;
-    return hash_combine(0, d._arch, d._tag, d._path.hash(), is_declaration);
+    return orc::hash_combine(0, d._arch, d._tag, d._path.hash(), is_declaration);
 };
 
 /**************************************************************************************************/
@@ -317,7 +317,7 @@ std::size_t fatal_attribute_hash(const attribute_sequence& attributes) {
 
     std::size_t h{0};
     for (const auto& name : names) {
-        h = hash_combine(h, attributes.hash(name));
+        h = orc::hash_combine(h, attributes.hash(name));
     }
     return h;
 }

--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -769,10 +769,10 @@ attribute_value dwarf::implementation::evaluate_exprloc(std::uint32_t expression
     while (_s.tellg() < end && !passover) {
         auto op = read_pod<dw::op>(_s);
         switch (op) {
-            case dw::op::lit0... dw::op::lit31: {
+            case dw::op::lit0 ... dw::op::lit31: { // gcc/clang extension
                 stack.push_back(static_cast<int>(op) - static_cast<int>(dw::op::reg0));
             } break;
-            case dw::op::reg0... dw::op::reg31: {
+            case dw::op::reg0 ... dw::op::reg31: { // gcc/clang extension
                 stack.push_back(static_cast<int>(op) - static_cast<int>(dw::op::reg0));
             } break;
             case dw::op::const1u: {
@@ -941,9 +941,7 @@ die_pair dwarf::implementation::abbreviation_to_die(std::size_t die_address, pro
 
     std::transform(a._attributes.begin(), a._attributes.end(), std::back_inserter(attributes),
                    [&](const auto& x) {
-                       // a possible optimization to think about...
-                       // if (mode == process_mode::complete && nonfatal_attribute(x._name)) return
-                       // x;
+                       // REVISIT (fosterbrereton) Can we skip processing nonfatal attributes?
                        return process_attribute(x, die._debug_info_offset);
                    });
 

--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -769,19 +769,45 @@ attribute_value dwarf::implementation::evaluate_exprloc(std::uint32_t expression
     while (_s.tellg() < end && !passover) {
         auto op = read_pod<dw::op>(_s);
         switch (op) {
-            case dw::op::lit0... dw::op::lit31: { stack.push_back(static_cast<int>(op) - static_cast<int>(dw::op::reg0)); } break;
-            case dw::op::reg0... dw::op::reg31: { stack.push_back(static_cast<int>(op) - static_cast<int>(dw::op::reg0)); } break;
-            case dw::op::const1u: { stack.push_back(read8()); } break;
-            case dw::op::const2u: { stack.push_back(read16()); } break;
-            case dw::op::const4u: { stack.push_back(read32()); } break;
-            case dw::op::const8u: { stack.push_back(read64()); } break;
-            case dw::op::const1s: { stack.push_back(read_pod<std::int8_t>(_s)); } break;
-            case dw::op::const2s: { stack.push_back(read_pod<std::int16_t>(_s)); } break;
-            case dw::op::const4s: { stack.push_back(read_pod<std::int32_t>(_s)); } break;
-            case dw::op::const8s: { stack.push_back(read_pod<std::int64_t>(_s)); } break;
-            case dw::op::constu: { stack.push_back(read_uleb()); } break;
-            case dw::op::consts: { stack.push_back(read_sleb()); } break;
-            case dw::op::regx: { stack.push_back(read_uleb()); } break;
+            case dw::op::lit0... dw::op::lit31: {
+                stack.push_back(static_cast<int>(op) - static_cast<int>(dw::op::reg0));
+            } break;
+            case dw::op::reg0... dw::op::reg31: {
+                stack.push_back(static_cast<int>(op) - static_cast<int>(dw::op::reg0));
+            } break;
+            case dw::op::const1u: {
+                stack.push_back(read8());
+            } break;
+            case dw::op::const2u: {
+                stack.push_back(read16());
+            } break;
+            case dw::op::const4u: {
+                stack.push_back(read32());
+            } break;
+            case dw::op::const8u: {
+                stack.push_back(read64());
+            } break;
+            case dw::op::const1s: {
+                stack.push_back(read_pod<std::int8_t>(_s));
+            } break;
+            case dw::op::const2s: {
+                stack.push_back(read_pod<std::int16_t>(_s));
+            } break;
+            case dw::op::const4s: {
+                stack.push_back(read_pod<std::int32_t>(_s));
+            } break;
+            case dw::op::const8s: {
+                stack.push_back(read_pod<std::int64_t>(_s));
+            } break;
+            case dw::op::constu: {
+                stack.push_back(read_uleb());
+            } break;
+            case dw::op::consts: {
+                stack.push_back(read_sleb());
+            } break;
+            case dw::op::regx: {
+                stack.push_back(read_uleb());
+            } break;
             case dw::op::dup: {
                 if (stack.empty()) {
                     passover = true;

--- a/src/dwarf_structs.cpp
+++ b/src/dwarf_structs.cpp
@@ -112,7 +112,7 @@ std::ostream& operator<<(std::ostream& s, const attribute_sequence& x) {
 /**************************************************************************************************/
 
 std::ostream& operator<<(std::ostream& s, const die& x) {
-    for (const auto& ancestor : x._ancestry) {
+    for (const auto& ancestor : *x._ancestry) {
         s << "    within: " << ancestor.allocate_path().filename().string() << ":\n";
     }
 

--- a/src/dwarf_structs.cpp
+++ b/src/dwarf_structs.cpp
@@ -86,41 +86,36 @@ std::ostream& operator<<(std::ostream& s, const attribute& x) {
 
 /**************************************************************************************************/
 
+std::ostream& operator<<(std::ostream& s, const attribute_sequence& x) {
+    if (x.has_string(dw::at::decl_file)) {
+        s << "        definition location: " << x.string(dw::at::decl_file);
+
+        if (x.has_uint(dw::at::decl_line)) {
+            s << ":" + std::to_string(x.uint(dw::at::decl_line));
+        }
+
+        s << '\n';
+    }
+
+    for (const auto& attr : x) {
+        if (attr._name == dw::at::decl_file) continue;
+        if (attr._name == dw::at::decl_line) continue;
+        s << attr << '\n';
+    }
+
+    return s;
+}
+
+/**************************************************************************************************/
+
 std::ostream& operator<<(std::ostream& s, const die& x) {
     for (const auto& ancestor: x._ancestry) {
         s << "    within: " << ancestor.allocate_path().filename().string() << ":\n";
     }
 
-#if 0
-    std::vector<attribute> attributes(x._attributes, x._attributes + x._attributes_size);
-
-    auto erase_attr = [](auto& attributes, auto key){
-        auto found = std::find_if(attributes.begin(), attributes.end(), [&](auto& x){
-            return x._name == key;
-        });
-
-        if (found != attributes.end())
-            attributes.erase(found);
-    };
-
-    bool first = true;
-    if (x.attribute_has_string(dw::at::decl_file)) {
-        s << "        definition location: " << x.attribute_string(dw::at::decl_file);
-        erase_attr(attributes, dw::at::decl_file);
-
-        if (x.attribute_has_uint(dw::at::decl_line)) {
-            s << ":" + std::to_string(x.attribute_uint(dw::at::decl_line));
-            erase_attr(attributes, dw::at::decl_line);
-        }
-
-        first = false;
-    }
-
-    for (const auto& attr : attributes) {
-        if (!first) s << '\n';
-        s << attr;
-        first = false;
-    }
+    // Save for debugging so we can map what we find with dwarfdump output
+#if 1
+    s << "        debug info offset: 0x" << std::hex << x._debug_info_offset << std::dec << '\n';
 #endif
 
     return s;

--- a/src/dwarf_structs.cpp
+++ b/src/dwarf_structs.cpp
@@ -12,6 +12,7 @@
 
 // application
 #include "orc/parse_file.hpp"
+#include "orc/object_file_registry.hpp"
 
 /**************************************************************************************************/
 
@@ -112,7 +113,7 @@ std::ostream& operator<<(std::ostream& s, const attribute_sequence& x) {
 /**************************************************************************************************/
 
 std::ostream& operator<<(std::ostream& s, const die& x) {
-    for (const auto& ancestor : *x._ancestry) {
+    for (const auto& ancestor : object_file_ancestry(x._ofd_index)) {
         s << "    within: " << ancestor.allocate_path().filename().string() << ":\n";
     }
 
@@ -122,6 +123,16 @@ std::ostream& operator<<(std::ostream& s, const die& x) {
 #endif
 
     return s;
+}
+
+/**************************************************************************************************/
+
+bool operator<(const die& x, const die& y) {
+    if (x._path.view() < y._path.view())
+        return true;
+    if (x._path.view() > y._path.view())
+        return false;
+    return object_file_ancestry(x._ofd_index) < object_file_ancestry(y._ofd_index);
 }
 
 /**************************************************************************************************/

--- a/src/dwarf_structs.cpp
+++ b/src/dwarf_structs.cpp
@@ -118,7 +118,7 @@ std::ostream& operator<<(std::ostream& s, const die& x) {
 
     // Save for debugging so we can map what we find with dwarfdump output
 #if 0
-    s << "        debug info offset: 0x" << std::hex << x._debug_info_offset << std::dec << '\n';
+    s << "        debug_info offset: " << hex_print(x._debug_info_offset) << '\n';
 #endif
 
     return s;

--- a/src/dwarf_structs.cpp
+++ b/src/dwarf_structs.cpp
@@ -43,9 +43,12 @@ void attribute::read(freader& s) {
 
 std::size_t attribute_value::hash() const {
     // order here matches operator==
-    if (has_string()) return string().hash();
-    else if (has_uint()) return uint();
-    else if (has_sint()) return sint();
+    if (has_string())
+        return string().hash();
+    else if (has_uint())
+        return uint();
+    else if (has_sint())
+        return sint();
     return static_cast<std::size_t>(type());
 }
 
@@ -109,12 +112,12 @@ std::ostream& operator<<(std::ostream& s, const attribute_sequence& x) {
 /**************************************************************************************************/
 
 std::ostream& operator<<(std::ostream& s, const die& x) {
-    for (const auto& ancestor: x._ancestry) {
+    for (const auto& ancestor : x._ancestry) {
         s << "    within: " << ancestor.allocate_path().filename().string() << ":\n";
     }
 
     // Save for debugging so we can map what we find with dwarfdump output
-#if 1
+#if 0
     s << "        debug info offset: 0x" << std::hex << x._debug_info_offset << std::dec << '\n';
 #endif
 
@@ -124,7 +127,7 @@ std::ostream& operator<<(std::ostream& s, const die& x) {
 /**************************************************************************************************/
 
 bool nonfatal_attribute(dw::at at) {
-    static const auto attributes = []{
+    static const auto attributes = [] {
         std::vector<dw::at> nonfatal_attributes = {
             dw::at::apple_block,
             dw::at::apple_flags,

--- a/src/fat.cpp
+++ b/src/fat.cpp
@@ -5,7 +5,9 @@
 // of the Adobe license agreement accompanying it.
 
 // identity
-#include "orc/fat.hpp" // application
+#include "orc/fat.hpp"
+
+// application
 #include "orc/mach_types.hpp"
 
 /**************************************************************************************************/

--- a/src/fat.cpp
+++ b/src/fat.cpp
@@ -5,7 +5,7 @@
 // of the Adobe license agreement accompanying it.
 
 // identity
-#include "orc/fat.hpp"// application
+#include "orc/fat.hpp" // application
 #include "orc/mach_types.hpp"
 
 /**************************************************************************************************/
@@ -40,11 +40,16 @@ struct fat_arch_64 {
 
 const char* cputype_to_string(cpu_type_t cputype) {
     switch (cputype) {
-        case CPU_TYPE_X86: return "arch.x86";
-        case CPU_TYPE_ARM: return "arch.arm";
-        case CPU_TYPE_X86_64: return "arch.x86_64";
-        case CPU_TYPE_ARM64: return "arch.arm64";
-        case CPU_TYPE_ARM64_32: return "arch.arm64_32";
+        case CPU_TYPE_X86:
+            return "arch.x86";
+        case CPU_TYPE_ARM:
+            return "arch.arm";
+        case CPU_TYPE_X86_64:
+            return "arch.x86_64";
+        case CPU_TYPE_ARM64:
+            return "arch.arm64";
+        case CPU_TYPE_ARM64_32:
+            return "arch.arm64_32";
     }
 
     return "arch.unknown";
@@ -75,7 +80,7 @@ void read_fat(object_ancestry&& ancestry,
         std::size_t offset{0};
         std::size_t size{0};
         cpu_type_t cputype{0};
-    
+
         if (is_64_bit) {
             auto arch = read_pod<fat_arch_64>(s);
             if (details._needs_byteswap) {
@@ -103,11 +108,8 @@ void read_fat(object_ancestry&& ancestry,
         }
 
         temp_seek(s, offset, [&] {
-            parse_file(cputype_to_string(cputype),
-                       ancestry,
-                       s,
-                       s.tellg() + static_cast<std::streamoff>(size),
-                       callbacks);
+            parse_file(cputype_to_string(cputype), ancestry, s,
+                       s.tellg() + static_cast<std::streamoff>(size), callbacks);
         });
     }
 }

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -1,0 +1,155 @@
+// Copyright 2022 Adobe
+// All Rights Reserved.
+//
+// NOTICE: Adobe permits you to use, modify, and distribute this file in accordance with the terms
+// of the Adobe license agreement accompanying it.
+
+// identity
+#include "orc/hash.hpp"
+
+/**************************************************************************************************/
+
+namespace {
+
+/**************************************************************************************************/
+
+#if defined(_MSC_VER)
+
+#define FORCE_INLINE __forceinline
+
+#include <stdlib.h>
+
+#define ROTL64(x, y) _rotl64(x, y)
+
+#define BIG_CONSTANT(x) (x)
+
+#else // defined(_MSC_VER)
+
+#define FORCE_INLINE inline __attribute__((always_inline))
+
+inline uint64_t rotl64(uint64_t x, int8_t r) { return (x << r) | (x >> (64 - r)); }
+
+#define ROTL64(x, y) rotl64(x, y)
+
+#define BIG_CONSTANT(x) (x##LLU)
+
+#endif // !defined(_MSC_VER)
+
+/**************************************************************************************************/
+
+FORCE_INLINE uint64_t getblock64(const uint64_t* p, int i) { return p[i]; }
+
+/**************************************************************************************************/
+
+FORCE_INLINE uint64_t fmix64(uint64_t k) {
+    k ^= k >> 33;
+    k *= BIG_CONSTANT(0xff51afd7ed558ccd);
+    k ^= k >> 33;
+    k *= BIG_CONSTANT(0xc4ceb9fe1a85ec53);
+    k ^= k >> 33;
+
+    return k;
+}
+
+/**************************************************************************************************/
+
+} // namespace
+
+/**************************************************************************************************/
+
+namespace orc {
+
+/**************************************************************************************************/
+
+murmur_hash murmur3(const void* key, int len, uint32_t seed) {
+    const uint8_t* data = (const uint8_t*)key;
+    const int nblocks = len / 16;
+
+    uint64_t h1 = seed;
+    uint64_t h2 = seed;
+
+    const uint64_t c1 = BIG_CONSTANT(0x87c37b91114253d5);
+    const uint64_t c2 = BIG_CONSTANT(0x4cf5ad432745937f);
+
+    //----------
+    // body
+
+    const uint64_t* blocks = (const uint64_t*)(data);
+
+    for (int i = 0; i < nblocks; i++) {
+        uint64_t k1 = getblock64(blocks, i * 2 + 0);
+        uint64_t k2 = getblock64(blocks, i * 2 + 1);
+
+        k1 *= c1;
+        k1 = ROTL64(k1, 31);
+        k1 *= c2;
+        h1 ^= k1;
+
+        h1 = ROTL64(h1, 27);
+        h1 += h2;
+        h1 = h1 * 5 + 0x52dce729;
+
+        k2 *= c2;
+        k2 = ROTL64(k2, 33);
+        k2 *= c1;
+        h2 ^= k2;
+
+        h2 = ROTL64(h2, 31);
+        h2 += h1;
+        h2 = h2 * 5 + 0x38495ab5;
+    }
+
+    //----------
+    // tail
+
+    const uint8_t* tail = (const uint8_t*)(data + nblocks * 16);
+
+    uint64_t k1 = 0;
+    uint64_t k2 = 0;
+
+    // clang-format off
+    switch(len & 15) {
+        case 15: k2 ^= ((uint64_t)tail[14]) << 48;
+        case 14: k2 ^= ((uint64_t)tail[13]) << 40;
+        case 13: k2 ^= ((uint64_t)tail[12]) << 32;
+        case 12: k2 ^= ((uint64_t)tail[11]) << 24;
+        case 11: k2 ^= ((uint64_t)tail[10]) << 16;
+        case 10: k2 ^= ((uint64_t)tail[ 9]) << 8;
+        case  9: k2 ^= ((uint64_t)tail[ 8]) << 0;
+               k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2;
+
+        case  8: k1 ^= ((uint64_t)tail[ 7]) << 56;
+        case  7: k1 ^= ((uint64_t)tail[ 6]) << 48;
+        case  6: k1 ^= ((uint64_t)tail[ 5]) << 40;
+        case  5: k1 ^= ((uint64_t)tail[ 4]) << 32;
+        case  4: k1 ^= ((uint64_t)tail[ 3]) << 24;
+        case  3: k1 ^= ((uint64_t)tail[ 2]) << 16;
+        case  2: k1 ^= ((uint64_t)tail[ 1]) << 8;
+        case  1: k1 ^= ((uint64_t)tail[ 0]) << 0;
+               k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
+    };
+    // clang-format on
+
+    //----------
+    // finalization
+
+    h1 ^= len;
+    h2 ^= len;
+
+    h1 += h2;
+    h2 += h1;
+
+    h1 = fmix64(h1);
+    h2 = fmix64(h2);
+
+    h1 += h2;
+    h2 += h1;
+
+    return murmur_hash{h1, h2};
+}
+
+/**************************************************************************************************/
+
+} // namespace orc
+
+/**************************************************************************************************/

--- a/src/macho.cpp
+++ b/src/macho.cpp
@@ -7,9 +7,6 @@
 // identity
 #include "orc/macho.hpp"
 
-// stdc++
-#include <map>
-
 // tbb
 #include <tbb/concurrent_map.h>
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -368,7 +368,6 @@ auto process_command_line(int argc, char** argv) {
 /**************************************************************************************************/
 
 auto epilogue(bool exception) {
-
     const auto& g = globals::instance();
 
     // If we were showing progress this session, take all the stored up ODRVs and output them
@@ -386,7 +385,9 @@ auto epilogue(bool exception) {
               << "  " << g._odrv_count << " ODRVs reported\n"
               << "  " << g._object_file_count << " compilation units processed\n"
               << "  " << g._die_processed_count << " dies processed\n"
-              << "  " << g._unique_symbol_count << " unique symbols registered\n";
+              << "  " << g._unique_symbol_count << " unique symbols registered\n"
+              << "  " << g._unique_symbol_die_count << " unique symbol dies\n"
+              ;
         });
     }
 
@@ -411,7 +412,6 @@ auto interrupt_callback_handler(int signum) {
 /**************************************************************************************************/
 
 void maybe_forward_to_linker(int argc, char** argv, const cmdline_results& cmdline) {
-
     if (!settings::instance()._forward_to_linker) return;
 
     std::filesystem::path executable_path =

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,15 +11,15 @@
 #include <fstream>
 #include <list>
 #include <mutex>
+#include <set>
 #include <thread>
 #include <unordered_map>
-#include <set>
 
 // stlab
 #include <stlab/concurrency/default_executor.hpp>
 #include <stlab/concurrency/future.hpp>
-#include <stlab/concurrency/utility.hpp>
 #include <stlab/concurrency/serial_queue.hpp>
+#include <stlab/concurrency/utility.hpp>
 
 // toml++
 #include <toml++/toml.h>
@@ -142,9 +142,9 @@ void process_orc_config_file(const char* bin_path_string) {
                 try {
                     std::string fn = *settings["output_file"].value<std::string>();
                     globals::instance()._fp.open(fn);
-                }
-                catch (const std::exception& e) {
-                    std::cout << "warning: Could not open output file: " << settings["output_file"] << "\n";
+                } catch (const std::exception& e) {
+                    std::cout << "warning: Could not open output file: " << settings["output_file"]
+                              << "\n";
                 }
             }
 
@@ -165,7 +165,7 @@ void process_orc_config_file(const char* bin_path_string) {
                 }
             }
 
-            auto read_string_list = [&_settings = settings](const char* name){
+            auto read_string_list = [&_settings = settings](const char* name) {
                 std::vector<std::string> result;
                 if (auto* array = _settings.get_as<toml::array>(name)) {
                     for (const auto& entry : *array) {
@@ -185,11 +185,13 @@ void process_orc_config_file(const char* bin_path_string) {
             if (!app_settings._violation_report.empty() &&
                 !app_settings._violation_ignore.empty()) {
                 if (log_level_at_least(settings::log_level::warning)) {
-                    std::cout << "warning: Both `violation_report` and `violation_ignore` lists found\n";
-                    std::cout << "warning: `violation_report` will be ignored in favor of `violation_ignore`\n";
+                    std::cout
+                        << "warning: Both `violation_report` and `violation_ignore` lists found\n";
+                    std::cout
+                        << "warning: `violation_report` will be ignored in favor of `violation_ignore`\n";
                 }
             }
-                
+
 
             if (log_level_at_least(settings::log_level::info)) {
                 std::cout << "info: ORC config file: " << config_path.string() << "\n";
@@ -208,7 +210,7 @@ void process_orc_config_file(const char* bin_path_string) {
 auto derive_filelist_file_list(const std::filesystem::path& filelist) {
     std::vector<std::filesystem::path> result;
     std::ifstream input(filelist, std::ios::binary);
-    
+
     if (!input) throw std::runtime_error("problem opening filelist for reading");
 
     static constexpr auto buffer_sz{1024};
@@ -217,8 +219,7 @@ auto derive_filelist_file_list(const std::filesystem::path& filelist) {
     // The link file list contains object files, one per line.
     while (input) {
         input.getline(&buffer[0], buffer_sz);
-        if (strnlen(&buffer[0], 1024))
-            result.push_back(&buffer[0]);
+        if (strnlen(&buffer[0], 1024)) result.push_back(&buffer[0]);
     }
 
     return result;
@@ -236,9 +237,8 @@ auto find_artifact(std::string_view type,
     }
 
     if (log_level_at_least(settings::log_level::warning)) {
-        cout_safe([&](auto& s){
-            s << "warning: Could not find " << type << " '" << artifact << "'\n";
-        });
+        cout_safe(
+            [&](auto& s) { s << "warning: Could not find " << type << " '" << artifact << "'\n"; });
     }
 
     return std::filesystem::path();
@@ -383,7 +383,7 @@ auto epilogue(bool exception) {
     }
 
     if (log_level_at_least(settings::log_level::info)) {
-        cout_safe([&](auto& s){
+        cout_safe([&](auto& s) {
             s << "info: ORC complete.\n"
               << "info:   " << g._odrv_count << " ODRVs reported\n"
               << "info:   " << g._object_file_count << " compilation units processed\n"
@@ -417,7 +417,8 @@ void maybe_forward_to_linker(int argc, char** argv, const cmdline_results& cmdli
 
     if (!settings::instance()._forward_to_linker) return;
 
-    std::filesystem::path executable_path = rstrip(exec("xcode-select -p")) + "/Toolchains/XcodeDefault.xctoolchain/usr/bin/";
+    std::filesystem::path executable_path =
+        rstrip(exec("xcode-select -p")) + "/Toolchains/XcodeDefault.xctoolchain/usr/bin/";
 
     if (cmdline._ld_mode) {
         if (settings::instance()._standalone_mode) {
@@ -435,7 +436,8 @@ void maybe_forward_to_linker(int argc, char** argv, const cmdline_results& cmdli
         executable_path /= "libtool";
     } else {
         if (log_level_at_least(settings::log_level::warning)) {
-            std::cout << "warning: libtool/ld mode could not be derived; forwarding to linker disabled\n";
+            std::cout
+                << "warning: libtool/ld mode could not be derived; forwarding to linker disabled\n";
         }
 
         return;
@@ -489,7 +491,8 @@ int main(int argc, char** argv) try {
     }
 
     for (const auto& report : orc_process(file_list)) {
-        std::cout << report;   // important to NOT add the '\n', because lots of reports are empty, and it creates a lot of blank lines
+        std::cout << report; // important to NOT add the '\n', because lots of reports are empty,
+                             // and it creates a lot of blank lines
     }
 
     return epilogue(false);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -388,7 +388,7 @@ auto epilogue(bool exception) {
               << "info:   " << g._odrv_count << " ODRVs reported\n"
               << "info:   " << g._object_file_count << " compilation units processed\n"
               << "info:   " << g._die_processed_count << " dies processed\n"
-              << "info:   " << g._die_registered_count << " dies registered\n";
+              << "info:   " << g._unique_symbol_count << " unique symbols registered\n";
         });
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -382,13 +382,13 @@ auto epilogue(bool exception) {
         // });
     }
 
-    if (log_level_at_least(settings::log_level::info)) {
+    if (log_level_at_least(settings::log_level::warning)) {
         cout_safe([&](auto& s) {
-            s << "info: ORC complete.\n"
-              << "info:   " << g._odrv_count << " ODRVs reported\n"
-              << "info:   " << g._object_file_count << " compilation units processed\n"
-              << "info:   " << g._die_processed_count << " dies processed\n"
-              << "info:   " << g._unique_symbol_count << " unique symbols registered\n";
+            s << "ORC complete.\n"
+              << "  " << g._odrv_count << " ODRVs reported\n"
+              << "  " << g._object_file_count << " compilation units processed\n"
+              << "  " << g._die_processed_count << " dies processed\n"
+              << "  " << g._unique_symbol_count << " unique symbols registered\n";
         });
     }
 

--- a/src/object_file_registry.cpp
+++ b/src/object_file_registry.cpp
@@ -1,0 +1,43 @@
+// Copyright 2021 Adobe
+// All Rights Reserved.
+//
+// NOTICE: Adobe permits you to use, modify, and distribute this file in accordance with the terms
+// of the Adobe license agreement accompanying it.
+
+// identity
+#include "orc/object_file_registry.hpp"
+
+// tbb
+#include <tbb/concurrent_vector.h>
+
+/**************************************************************************************************/
+
+namespace {
+
+/**************************************************************************************************/
+
+tbb::concurrent_vector<object_file_descriptor>& obj_registry() {
+    static tbb::concurrent_vector<object_file_descriptor> result;
+    return result;
+}
+
+/**************************************************************************************************/
+
+} // namespace
+    
+/**************************************************************************************************/
+
+std::size_t object_file_register(object_ancestry&& ancestry, file_details&& details) {
+    // According to the OneTBB website,
+    // "Growing the container does not invalidate any existing iterators or indices."
+    // https://spec.oneapi.io/versions/latest/elements/oneTBB/source/containers/concurrent_vector_cls.html
+
+    auto result = obj_registry().emplace_back(object_file_descriptor{std::move(ancestry), std::move(details)});
+    return std::distance(obj_registry().begin(), result);
+}
+
+const object_file_descriptor& object_file_fetch(std::size_t index) {
+    return obj_registry()[index];
+}
+
+/**************************************************************************************************/

--- a/src/orc.cpp
+++ b/src/orc.cpp
@@ -454,11 +454,6 @@ std::ostream& operator<<(std::ostream& s, const odrv_report& report) {
 
 void enforce_odrv_for_die_list(die* base, std::vector<odrv_report>& results)
 {
-    if (base->_hash == 6295459837195399299) {
-        int x;
-        (void)x;
-    }
-
     std::vector<die*> dies;
     for(die* ptr = base; ptr; ptr = ptr->_next_die) {
         dies.push_back(ptr);
@@ -475,12 +470,12 @@ void enforce_odrv_for_die_list(die* base, std::vector<odrv_report>& results)
     });
 
     bool conflict{false};
-    for(size_t i=1; i<dies.size(); ++i) {
+    for(size_t i = 1; i < dies.size(); ++i) {
         // Re-link the die list to match the sorted order.
         dies[i-1]->_next_die = dies[i];
 
         if (!conflict) {
-            conflict = dies[0]->_fatal_attribute_hash != dies[1]->_fatal_attribute_hash;
+            conflict = dies[i-1]->_fatal_attribute_hash != dies[i]->_fatal_attribute_hash;
         }
     }
     dies.back()->_next_die = nullptr;

--- a/src/orc.cpp
+++ b/src/orc.cpp
@@ -128,13 +128,6 @@ bool type_equivalent(const attribute& x, const attribute& y) {
         return true;
     }
 
-    if (x.has(attribute_value::type::die) && y.has(attribute_value::type::die)) {
-        assert(false); // not sure what to do here...
-        // if (find_die_conflict(x.die(), y.die()) == dw::at::none) {
-        //     return true; // Should this change based on find_die_conflict's result?
-        // }
-    }
-
     // Type mismatch.
     return false;
 }
@@ -369,8 +362,8 @@ attribute_sequence fetch_attributes_for_die(const die& d) {
 
 /**************************************************************************************************/
 
-odrv_report::odrv_report(std::string_view symbol, const die* list_head) :
-    _symbol(symbol), _list_head(list_head) {
+odrv_report::odrv_report(std::string_view symbol, const die* list_head)
+    : _symbol(symbol), _list_head(list_head) {
     assert(_list_head->_conflict);
 
     // Construct a map of unique definitions of the conflicting symbol.
@@ -398,7 +391,8 @@ odrv_report::odrv_report(std::string_view symbol, const die* list_head) :
 /**************************************************************************************************/
 
 std::string odrv_report::category() const {
-    return to_string(_conflict_map.begin()->second._die->_tag) + std::string(":") + to_string(_name);
+    return to_string(_conflict_map.begin()->second._die->_tag) + std::string(":") +
+           to_string(_name);
 }
 
 /**************************************************************************************************/

--- a/src/orc.cpp
+++ b/src/orc.cpp
@@ -354,7 +354,7 @@ const char* problem_prefix() { return settings::instance()._graceful_exit ? "war
 /**************************************************************************************************/
 
 attribute_sequence fetch_attributes_for_die(const die& d) {
-    auto dwarf = dwarf_from_macho(copy(d._ancestry), register_dies_callback());
+    auto dwarf = dwarf_from_macho(*d._ancestry, register_dies_callback());
     auto [die, attributes] = dwarf.fetch_one_die(d._debug_info_offset);
     assert(die._tag == d._tag);
     assert(die._arch == d._arch);

--- a/src/orc.cpp
+++ b/src/orc.cpp
@@ -203,16 +203,7 @@ void register_dies(dies die_vector) {
     globals::instance()._die_processed_count += dies.size();
 
     for (auto& d : dies) {
-        // save for debugging. Useful to watch for a specific symbol.
-#if 0
-        if (d._path == "::[u]::_ZNK14example_vtable6object3apiEv") {
-            int x;
-            (void)x;
-        }
-#endif
-
-        if (d._should_skip) continue;
-
+        if (d._skippable) continue;
 #if 0
         if (settings::instance()._print_symbol_paths) {
             // This is all horribly broken, especially now that we're calling this from multiple threads.

--- a/src/orc.cpp
+++ b/src/orc.cpp
@@ -451,7 +451,7 @@ void enforce_odrv_for_die_list(die* base, std::vector<odrv_report>& results) {
     // the ancestry might not be unique. We assume that's an edge case
     // and the ancestry is unique.
     std::sort(dies.begin(), dies.end(),
-              [](const die* a, const die* b) { return a->_ancestry < b->_ancestry; });
+              [](const die* a, const die* b) { return *a->_ancestry < *b->_ancestry; });
 
     bool conflict{false};
     for (size_t i = 1; i < dies.size(); ++i) {

--- a/src/parse_file.cpp
+++ b/src/parse_file.cpp
@@ -99,9 +99,7 @@ auto mmap_file(const std::filesystem::path& p) {
     void* ptr = mmap(nullptr, size, PROT_READ, MAP_SHARED, fd, 0);
     close(fd);
     if (ptr == MAP_FAILED) return result_type();
-    auto deleter = [_sz = size](void* x){
-        munmap(x, _sz);
-    };
+    auto deleter = [_sz = size](void* x) { munmap(x, _sz); };
     return result_type(static_cast<char*>(ptr), std::move(deleter));
 }
 
@@ -117,7 +115,8 @@ std::uint32_t uleb128(freader& s) {
 
     while (true) {
         auto c = s.get();
-        if (shift < 32) // shifts above 32 on uint32_t are undefined, but the s.get() needs to continue.
+        if (shift <
+            32) // shifts above 32 on uint32_t are undefined, but the s.get() needs to continue.
             result |= (c & 0x7f) << shift;
         if (!(c & 0x80)) return result;
         shift += 7;
@@ -144,7 +143,7 @@ std::int32_t sleb128(freader& s) {
     constexpr auto size_k{sizeof(result) * 8};
 
     if (sign && shift < size_k) {
-        result |= - (1 << shift);
+        result |= -(1 << shift);
     }
 
     return result;
@@ -167,20 +166,20 @@ void parse_file(std::string_view object_name,
         case file_details::format::unknown:
             throw std::runtime_error("unknown format");
         case file_details::format::macho:
-            return read_macho(std::move(new_ancestry), s, end_pos, std::move(detection), std::move(callbacks));
+            return read_macho(std::move(new_ancestry), s, end_pos, std::move(detection),
+                              std::move(callbacks));
         case file_details::format::ar:
-            return read_ar(std::move(new_ancestry), s, end_pos, std::move(detection), std::move(callbacks));
+            return read_ar(std::move(new_ancestry), s, end_pos, std::move(detection),
+                           std::move(callbacks));
         case file_details::format::fat:
-            return read_fat(std::move(new_ancestry), s, end_pos, std::move(detection), std::move(callbacks));
+            return read_fat(std::move(new_ancestry), s, end_pos, std::move(detection),
+                            std::move(callbacks));
     }
 }
 
 /**************************************************************************************************/
 
-freader::freader(const std::filesystem::path& p) :
-    _buffer(mmap_file(p)),
-    _f(_buffer.get()),
-    _p(_f),
-    _l(_p + std::filesystem::file_size(p)) {}
+freader::freader(const std::filesystem::path& p)
+    : _buffer(mmap_file(p)), _f(_buffer.get()), _p(_f), _l(_p + std::filesystem::file_size(p)) {}
 
 /**************************************************************************************************/

--- a/src/parse_file.cpp
+++ b/src/parse_file.cpp
@@ -99,7 +99,9 @@ auto mmap_file(const std::filesystem::path& p) {
     void* ptr = mmap(nullptr, size, PROT_READ, MAP_SHARED, fd, 0);
     close(fd);
     if (ptr == MAP_FAILED) return result_type();
-    auto deleter = [_sz = size](char* x){ munmap(x, _sz); };
+    auto deleter = [_sz = size](void* x){
+        munmap(x, _sz);
+    };
     return result_type(static_cast<char*>(ptr), std::move(deleter));
 }
 
@@ -159,7 +161,7 @@ void parse_file(std::string_view object_name,
 
     // append this object name to the ancestry
     object_ancestry new_ancestry = ancestry;
-    new_ancestry.emplace_back(callbacks._empool(object_name));
+    new_ancestry.emplace_back(empool(object_name));
 
     switch (detection._format) {
         case file_details::format::unknown:

--- a/src/string_pool.cpp
+++ b/src/string_pool.cpp
@@ -8,13 +8,13 @@
 #include "orc/string_pool.hpp"
 
 // stdc++
+#include <cassert>
 #include <cstring>
 #include <memory>
 #include <mutex>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
-#include <cassert>
-#include <unordered_map>
 
 // application
 #include "orc/features.hpp"
@@ -32,7 +32,7 @@ namespace {
 //      'size_t' hash
 // The _data pointer is returned to a null terminated string, to make debugging easier
 // get_size() and get_hash() unpack this data as needed.
-// 
+//
 struct pool {
     char* _p{nullptr};
     std::size_t _n{0};
@@ -42,7 +42,7 @@ struct pool {
         constexpr auto default_min_k = 16 * 1024 * 1024; // 16MB
         const uint32_t sz = (uint32_t)incoming.size();
         const uint32_t tsz = sz + sizeof(uint32_t) + sizeof(size_t) + 1;
-        
+
         if (_n < tsz) {
             _n = std::max<std::size_t>(default_min_k, tsz);
             _ponds.push_back(std::make_unique<char[]>(_n));
@@ -54,7 +54,7 @@ struct pool {
         std::memcpy(_p + sizeof(uint32_t), &h, sizeof(size_t));
         std::memcpy(_p + sizeof(uint32_t) + sizeof(size_t), incoming.data(), sz);
         *(_p + tsz - 1) = 0; // null terminate for debugging
-        
+
         const char* result = _p + sizeof(uint32_t) + sizeof(size_t);
         _n -= tsz;
         _p += tsz;
@@ -69,9 +69,9 @@ std::size_t pool_string::get_size(const char* d) {
     assert(d);
     const void* bytes = d - sizeof(std::uint32_t) - sizeof(std::size_t);
     std::uint32_t s;
-    std::memcpy(&s, bytes, sizeof(s));  // not aligned - need to use memcpy
-    assert(s > 0);         // required, else should have been _data == nullptr
-    assert(s < 100000);    // sanity check
+    std::memcpy(&s, bytes, sizeof(s)); // not aligned - need to use memcpy
+    assert(s > 0);                     // required, else should have been _data == nullptr
+    assert(s < 100000);                // sanity check
     return s;
 }
 
@@ -87,28 +87,27 @@ pool_string empool(std::string_view src) {
     // A pool_string is empty iff _data = nullptr
     // So this creates an empty pool_string (as opposed to an empty string_view, where
     // default_view would be returned.)
-    if (src.empty())
-        return pool_string(nullptr);
-    
+    if (src.empty()) return pool_string(nullptr);
+
     struct pool_key_to_hash {
-        auto operator()(size_t key) const { return key;}
+        auto operator()(size_t key) const { return key; }
     };
 
     thread_local std::unordered_multimap<size_t, const char*, pool_key_to_hash> keys;
     thread_local pool the_pool;
-    
+
     // Is the string interned already?
     const size_t h = std::hash<std::string_view>{}(src);
-    
+
     const auto range = keys.equal_range(h);
-    for(auto it = range.first; it != range.second; ++it) {
+    for (auto it = range.first; it != range.second; ++it) {
         pool_string ps(it->second);
         if (ps.view() == src) {
             return ps;
         }
     }
-    
-    // Not already interned; empool it and add to the 'keys' 
+
+    // Not already interned; empool it and add to the 'keys'
     const char* ptr = the_pool.empool(src);
     keys.insert({{h, ptr}});
     return pool_string(ptr);

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -390,9 +390,8 @@ bool odrv_report_match(const expected_odrv& odrv, const odrv_report& report) {
 
     const std::string& linkage_name = demangle(odrv.linkage_name().c_str());
     if (!linkage_name.empty()) {
-        dwarf dwarf = dwarf_from_macho(*report._list_head->_ancestry, register_dies_callback());
-        die_pair pair = dwarf.fetch_one_die(report._list_head->_debug_info_offset);
-        const char* report_linkage_name = demangle(std::get<1>(pair).string(dw::at::linkage_name).view().begin());
+        const auto& die_pair = report.conflict_map().begin()->second;
+        const char* report_linkage_name = demangle(die_pair._attributes.string(dw::at::linkage_name).view().begin());
         if (linkage_name != report_linkage_name)
             return false;
     }

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -14,6 +14,8 @@
 #include <toml++/toml.h>
 
 // orc
+#include <orc/dwarf.hpp>
+#include <orc/macho.hpp>
 #include <orc/orc.hpp>
 
 /**************************************************************************************************/
@@ -386,10 +388,12 @@ bool odrv_report_match(const expected_odrv& odrv, const odrv_report& report) {
         return false;
     }
 
-    const std::string& linkage_name = odrv.linkage_name();
+    const std::string& linkage_name = demangle(odrv.linkage_name().c_str());
     if (!linkage_name.empty()) {
-        const pool_string report_linkage_name = report._list_head->attribute_string(dw::at::linkage_name);
-        if (linkage_name != report_linkage_name.view())
+        dwarf dwarf = dwarf_from_macho(copy(report._list_head->_ancestry), register_dies_callback());
+        die_pair pair = dwarf.fetch_one_die(report._list_head->_debug_info_offset);
+        const char* report_linkage_name = demangle(std::get<1>(pair).string(dw::at::linkage_name).view().begin());
+        if (linkage_name != report_linkage_name)
             return false;
     }
     return true;

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -390,7 +390,7 @@ bool odrv_report_match(const expected_odrv& odrv, const odrv_report& report) {
 
     const std::string& linkage_name = demangle(odrv.linkage_name().c_str());
     if (!linkage_name.empty()) {
-        dwarf dwarf = dwarf_from_macho(copy(report._list_head->_ancestry), register_dies_callback());
+        dwarf dwarf = dwarf_from_macho(*report._list_head->_ancestry, register_dies_callback());
         die_pair pair = dwarf.fetch_one_die(report._list_head->_debug_info_offset);
         const char* report_linkage_name = demangle(std::get<1>(pair).string(dw::at::linkage_name).view().begin());
         if (linkage_name != report_linkage_name)


### PR DESCRIPTION
The theory of this PR is that in the first pass we avoid processing the attributes as much as possible. Instead, we spin them up long enough to generate a “fatal hash”, that is, a hash of the attributes that, if they were to conflict would be an ODRV. A given die stores the fatal hash instead of its attributes. This makes the dies considerably smaller. Conflict detection becomes a matter of comparing fatal hashes between two dies. During the reporting phase of the tool, we reopen the file on disk, and pull the attributes out of the DWARF data for just the conflicting dies. Then we serialize those out in the report, and Bob’s your uncle.