### PR TITLE
Steve Brooks' ORC Allocator

### DIFF
--- a/include/orc/allocator.hpp
+++ b/include/orc/allocator.hpp
@@ -1,0 +1,75 @@
+// Copyright 2022 Adobe
+// All Rights Reserved.
+//
+// NOTICE: Adobe permits you to use, modify, and distribute this file in accordance with the terms
+// of the Adobe license agreement accompanying it.
+
+#pragma once
+
+// stdc++
+#include <string>
+
+// application
+#include "orc/features.hpp"
+
+#define ORC_PRIVATE_FEATURE_ALLOCATOR() 1
+#define ORC_PRIVATE_FEATURE_ALLOCATOR_METRICS() (ORC_PRIVATE_FEATURE_ALLOCATOR() && 1)
+
+/**************************************************************************************************/
+
+#if ORC_FEATURE(ALLOCATOR)
+
+/**************************************************************************************************/
+
+namespace orc {
+
+/**************************************************************************************************/
+
+struct allocator_base {
+#if ORC_FEATURE(ALLOCATOR_METRICS)
+    static std::size_t hits();
+    static std::size_t misses();
+    static std::size_t total();
+#endif // ORC_FEATURE(ALLOCATOR_METRICS)
+
+protected:
+    static void* alloc(size_t size);
+    static void dealloc(void* p, size_t size);
+};
+
+/**************************************************************************************************/
+
+template <class T>
+struct allocator : private allocator_base {
+    using value_type = T;
+    using size_type = size_t;
+    using pointer = T*;
+    using const_pointer = const T*;
+
+    allocator() noexcept = default;
+    template <class U>
+    allocator(const allocator<U>&) noexcept {};
+    ~allocator() noexcept = default;
+
+    static pointer allocate(size_type n, const void* /*hint*/ = nullptr) {
+        return static_cast<pointer>(alloc(sizeof(value_type) * n)); // ignore possible overflow
+    }
+
+    static void deallocate(pointer p, size_type n) {
+        dealloc(p, sizeof(value_type) * n); // ignore possible overflow
+    }
+
+    // any two allocator<T>'s are the same
+    friend bool operator==(const allocator<T>&, const allocator<T>&) { return true; }
+    friend bool operator!=(const allocator<T>&, const allocator<T>&) { return false; }
+};
+
+/**************************************************************************************************/
+
+} // namespace orc
+
+/**************************************************************************************************/
+
+#endif // ORC_FEATURE(ALLOCATOR)
+
+/**************************************************************************************************/

--- a/include/orc/string.hpp
+++ b/include/orc/string.hpp
@@ -1,0 +1,35 @@
+// Copyright 2022 Adobe
+// All Rights Reserved.
+//
+// NOTICE: Adobe permits you to use, modify, and distribute this file in accordance with the terms
+// of the Adobe license agreement accompanying it.
+
+#pragma once
+
+// stdc++
+#include <string>
+
+// application
+#include "orc/allocator.hpp"
+
+/**************************************************************************************************/
+
+namespace orc {
+
+/**************************************************************************************************/
+
+#if ORC_FEATURE(ALLOCATOR)
+
+using string = std::basic_string<char, std::char_traits<char>, orc::allocator<char>>;
+
+#else
+
+using string = std::string;
+
+#endif // ORC_FEATURE(ALLOCATOR)
+
+/**************************************************************************************************/
+
+} // namespace orc
+
+/**************************************************************************************************/

--- a/include/orc/string_pool.hpp
+++ b/include/orc/string_pool.hpp
@@ -12,6 +12,9 @@
 #include <string_view>
 #include <filesystem>
 
+// application
+#include "orc/string.hpp"
+
 /**************************************************************************************************/
 
 struct pool_string;
@@ -53,8 +56,8 @@ struct pool_string {
         return std::string_view(_data, size);
     }
     
-    std::string allocate_string() const { 
-        return std::string(view()); 
+    orc::string allocate_string() const { 
+        return orc::string(view()); 
     }
     
     std::filesystem::path allocate_path() const { 

--- a/include/orc/vector.hpp
+++ b/include/orc/vector.hpp
@@ -1,0 +1,37 @@
+// Copyright 2022 Adobe
+// All Rights Reserved.
+//
+// NOTICE: Adobe permits you to use, modify, and distribute this file in accordance with the terms
+// of the Adobe license agreement accompanying it.
+
+#pragma once
+
+// stdc++
+#include <vector>
+
+// application
+#include "orc/allocator.hpp"
+
+/**************************************************************************************************/
+
+namespace orc {
+
+/**************************************************************************************************/
+
+#if ORC_FEATURE(ALLOCATOR)
+
+template <class T>
+using vector = std::vector<T, orc::allocator<T>>;
+
+#else
+
+template <class T>
+using vector = std::vector<T>;
+
+#endif // ORC_FEATURE(ALLOCATOR)
+
+/**************************************************************************************************/
+
+} // namespace orc
+
+/**************************************************************************************************/

--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -1,0 +1,119 @@
+// Copyright 2022 Adobe
+// All Rights Reserved.
+//
+// NOTICE: Adobe permits you to use, modify, and distribute this file in accordance with the terms
+// of the Adobe license agreement accompanying it.
+
+// identity
+#include "orc/allocator.hpp"
+
+// stdc++
+#include <cassert>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+// application
+
+/**************************************************************************************************/
+
+#if ORC_FEATURE(ALLOCATOR)
+
+/**************************************************************************************************/
+
+namespace {
+
+/**************************************************************************************************/
+#if ORC_FEATURE(ALLOCATOR_METRICS)
+std::atomic_size_t hit_count_g{0};
+std::atomic_size_t alloc_count_g{0};
+#endif // ORC_FEATURE(ALLOCATOR_METRICS)
+/**************************************************************************************************/
+
+struct alloc_info {
+    std::vector<void*> _recycled_pointers;
+};
+
+/**************************************************************************************************/
+
+auto& alloc_size_map() {
+    // maps alloc size to recycled pointers of that size
+    // pointer avoids thread shutdown crashes, and deliberate leaks allow quick shutdown
+    thread_local auto* p = new std::unordered_map<size_t, alloc_info>;
+    return *p;
+}
+
+/**************************************************************************************************/
+
+static constexpr size_t alloc_threshold_k = 1024; // recycling kicks in when malloc size <= this
+
+/**************************************************************************************************/
+
+} // namespace
+
+/**************************************************************************************************/
+
+namespace orc {
+
+/**************************************************************************************************/
+
+void* allocator_base::alloc(size_t size) {
+#if ORC_FEATURE(ALLOCATOR_METRICS)
+    ++alloc_count_g;
+#endif // ORC_FEATURE(ALLOCATOR_METRICS)
+
+    if (size > alloc_threshold_k) return malloc(size);
+
+    auto& size_map = alloc_size_map();
+    auto iter = size_map.find(size);
+
+    if (iter == size_map.end()) {
+        // ensure an alloc_info has been associated with this size
+        auto inserted = size_map.insert(std::make_pair(size, alloc_info()));
+        assert(inserted.second);
+        iter = std::move(inserted.first);
+    }
+
+    alloc_info& info = iter->second;
+
+    if (!info._recycled_pointers.empty()) {
+        // use a recycled pointer from the _recycled_pointers vector
+        void* result = info._recycled_pointers.back();
+        info._recycled_pointers.pop_back();
+#if ORC_FEATURE(ALLOCATOR_METRICS)
+        ++hit_count_g;
+#endif // ORC_FEATURE(ALLOCATOR_METRICS)
+        return result;
+    } else {
+        // nothing available to recycle, so allocate one
+        return malloc(size);
+    }
+}
+
+/**************************************************************************************************/
+
+void allocator_base::dealloc(void* p, size_t size) {
+    if (size > alloc_threshold_k) return free(p);
+
+    auto& size_map = alloc_size_map();
+    auto iter = size_map.find(size);
+    assert(iter != size_map.end());
+
+    iter->second._recycled_pointers.push_back(p);
+}
+
+/**************************************************************************************************/
+#if ORC_FEATURE(ALLOCATOR_METRICS)
+std::size_t allocator_base::hits() { return hit_count_g; }
+std::size_t allocator_base::misses() { return alloc_count_g - hit_count_g; }
+std::size_t allocator_base::total() { return alloc_count_g; }
+#endif // ORC_FEATURE(ALLOCATOR_METRICS)
+/**************************************************************************************************/
+
+} // namespace orc
+
+/**************************************************************************************************/
+
+#endif // ORC_FEATURE(ALLOCATOR)
+
+/**************************************************************************************************/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -382,13 +382,24 @@ auto epilogue(bool exception) {
         // });
     }
 
-    if (log_level_at_least(settings::log_level::info)) {
-        cout_safe([&](auto& s){
-            s << "info: ORC complete.\n"
-              << "info:   " << g._odrv_count << " ODRVs reported\n"
-              << "info:   " << g._object_file_count << " compilation units processed\n"
-              << "info:   " << g._die_processed_count << " dies processed\n"
-              << "info:   " << g._die_registered_count << " dies registered\n";
+    if (log_level_at_least(settings::log_level::warning)) {
+        cout_safe([&](auto& s) {
+#if ORC_FEATURE(ALLOCATOR_METRICS)
+            auto alloc_total = orc::allocator_base::total();
+            auto alloc_hits = orc::allocator_base::hits();
+            auto hit_pct = static_cast<double>(alloc_hits) / alloc_total * 100.;
+#endif // ORC_FEATURE(ALLOCATOR_METRICS)
+
+            s << "ORC complete.\n"
+              << "  " << g._odrv_count << " ODRVs reported\n"
+              << "  " << g._object_file_count << " compilation units processed\n"
+              << "  " << g._die_processed_count << " dies processed\n"
+              << "  " << g._die_registered_count << " dies registered\n"
+#if ORC_FEATURE(ALLOCATOR_METRICS)
+              << "  " << alloc_hits << " / " << alloc_total
+              << " (" << std::setprecision(4) << hit_pct << "%) memory cache hits/total\n"
+#endif // ORC_FEATURE(ALLOCATOR_METRICS)
+            ;
         });
     }
 

--- a/src/orc.cpp
+++ b/src/orc.cpp
@@ -31,6 +31,7 @@
 #include <tbb/concurrent_unordered_map.h>
 
 // application
+#include "orc/allocator.hpp"
 #include "orc/features.hpp"
 #include "orc/parse_file.hpp"
 #include "orc/settings.hpp"
@@ -278,7 +279,14 @@ auto with_global_die_collection(F&& f) {
 /**************************************************************************************************/
 
 auto& global_die_map() {
+#if ORC_FEATURE(ALLOCATOR)
+    using map_type = tbb::concurrent_unordered_map<std::size_t, die*,
+                                                   std::hash<size_t>,
+                                                   std::equal_to<size_t>,
+                                                   orc::allocator<std::pair<size_t const, die*>>>;
+#else // ORC_FEATURE(ALLOCATOR)
     using map_type = tbb::concurrent_unordered_map<std::size_t, die*>;
+#endif
 
 #if ORC_FEATURE(LEAKY_MEMORY)
     static map_type* map_s = new map_type;


### PR DESCRIPTION
This change improves memory handling by adding a custom allocator to many standard library types (vector and string most notably.) The custom allocators will keep a thread-local pool of memory blocks that have been freed, in the hopes that an allocation of the same size is not far off, and the memory can be recycled. The current implementation limits this recycling behavior to allocations of 1024 bytes or fewer.

The change also includes a handful of metrics that are reported at the end of the ORC run, that show memory cache hits and misses.

Both the allocator and the metrics therein are compile-time enabled via feature flags.

This PR is dedicated to Steve Brooks who recently retired from Adobe. It was Steve's inspiration and hard work that led to the discovery of these allocation patterns. Steve also contributed the bulk of the changes that made this PR possible.