### PR TITLE
Reduce the die size by 8 bytes

### DIFF
--- a/include/orc/dwarf_structs.hpp
+++ b/include/orc/dwarf_structs.hpp
@@ -12,7 +12,6 @@
 #include <cstdint>
 #include <string>
 #include <vector>
-#include <functional>
 
 // application
 #include "orc/dwarf_constants.hpp"

--- a/include/orc/dwarf_structs.hpp
+++ b/include/orc/dwarf_structs.hpp
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <functional>
 
 // application
 #include "orc/dwarf_constants.hpp"
@@ -226,7 +227,6 @@ struct die {
     pool_string _path;
     attribute* _attributes{nullptr};
     die* _next_die{nullptr};
-    std::size_t _hash{0};
     std::uint32_t _debug_info_offset{0}; // relative from top of __debug_info
     dw::tag _tag{dw::tag::none};
     std::uint8_t _attributes_size{0};

--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -1015,8 +1015,6 @@ void dwarf::implementation::process() {
             }
 
             die._ancestry = _ancestry;
-            //die._hash = die_hash(die); // precompute the hash we'll use for the die map.
-
             dies.push_back(std::move(die));
         }
     }

--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -188,11 +188,6 @@ struct file_name {
 
 /**************************************************************************************************/
 
-std::size_t die_hash(const die& d) {
-    bool is_declaration = d.has_attribute(dw::at::declaration) &&
-                          d.attribute_uint(dw::at::declaration) == 1;
-    return hash_combine(0, d._arch, d._tag, d._path.hash(), is_declaration);
-};
 
 /**************************************************************************************************/
 
@@ -1020,7 +1015,7 @@ void dwarf::implementation::process() {
             }
 
             die._ancestry = _ancestry;
-            die._hash = die_hash(die); // precompute the hash we'll use for the die map.
+            //die._hash = die_hash(die); // precompute the hash we'll use for the die map.
 
             dies.push_back(std::move(die));
         }

--- a/src/orc.cpp
+++ b/src/orc.cpp
@@ -347,8 +347,8 @@ void register_dies(dies die_vector) {
         // work exclusive to DIEs getting registered/odr-enforced.
         //
 
-        size_t h = die_hash(d);
-        auto result = global_die_map().insert(std::make_pair(h, &d));
+        size_t hash = die_hash(d);
+        auto result = global_die_map().insert(std::make_pair(hash, &d));
         if (result.second) {
             ++globals::instance()._die_registered_count;
             continue;
@@ -356,7 +356,7 @@ void register_dies(dies die_vector) {
 
         constexpr auto mutex_count_k = 67; // prime; to help reduce any hash bias
         static std::mutex mutexes_s[mutex_count_k];
-        std::lock_guard<std::mutex> lock(mutexes_s[h % mutex_count_k]);
+        std::lock_guard<std::mutex> lock(mutexes_s[hash % mutex_count_k]);
 
         die& d_in_map = *result.first->second;
         d._next_die = d_in_map._next_die;

--- a/src/orc.cpp
+++ b/src/orc.cpp
@@ -289,6 +289,12 @@ auto& global_die_map() {
 #endif
 }
 
+inline std::size_t die_hash(const die& d) {
+    bool is_declaration = d.has_attribute(dw::at::declaration) &&
+                          d.attribute_uint(dw::at::declaration) == 1;
+    return hash_combine(0, d._arch, d._tag, d._path.hash(), is_declaration);
+};
+
 /**************************************************************************************************/
 
 void register_dies(dies die_vector) {
@@ -341,7 +347,8 @@ void register_dies(dies die_vector) {
         // work exclusive to DIEs getting registered/odr-enforced.
         //
 
-        auto result = global_die_map().insert(std::make_pair(d._hash, &d));
+        size_t h = die_hash(d);
+        auto result = global_die_map().insert(std::make_pair(h, &d));
         if (result.second) {
             ++globals::instance()._die_registered_count;
             continue;
@@ -349,7 +356,7 @@ void register_dies(dies die_vector) {
 
         constexpr auto mutex_count_k = 67; // prime; to help reduce any hash bias
         static std::mutex mutexes_s[mutex_count_k];
-        std::lock_guard<std::mutex> lock(mutexes_s[d._hash % mutex_count_k]);
+        std::lock_guard<std::mutex> lock(mutexes_s[h % mutex_count_k]);
 
         die& d_in_map = *result.first->second;
         d._next_die = d_in_map._next_die;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The heavily used `die` is currently 96 bytes. With this PR, it is brought down to 88 bytes, by removing the _hash member. We still need the hash to store the die in the global map, but it can be computed on demand.

