### PR TITLE
Prefer `memcpy` to cast of unaligned pointer

### DIFF
--- a/include/orc/memory.hpp
+++ b/include/orc/memory.hpp
@@ -46,6 +46,16 @@ decltype(auto) make_leaky(Args&&... args) {
 }
 
 /**************************************************************************************************/
+// Useful for reading integer values (that otherwise need to be aligned) from unaligned memory. The
+// typical solution is to use memcpy and let the compiler optimize it further.
+template <class Integer>
+Integer unaligned_read(const void* p) {
+    Integer result{Integer()};
+    std::memcpy(&result, p, sizeof(result));
+    return result;
+}
+
+/**************************************************************************************************/
 
 } // namespace orc
 

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -7,6 +7,9 @@
 // identity
 #include "orc/hash.hpp"
 
+// application
+#include "orc/memory.hpp"
+
 /**************************************************************************************************/
 
 namespace {
@@ -37,7 +40,9 @@ inline uint64_t rotl64(uint64_t x, int8_t r) { return (x << r) | (x >> (64 - r))
 
 /**************************************************************************************************/
 
-FORCE_INLINE uint64_t getblock64(const uint64_t* p, int i) { return p[i]; }
+FORCE_INLINE std::uint64_t getblock64(const uint64_t* p, int i) {
+    return orc::unaligned_read<std::uint64_t>(p + i);
+}
 
 /**************************************************************************************************/
 


### PR DESCRIPTION
Provide an `unaligned_read` routine for reading integers at any memory address, not just those that are at language-prescribed alignment offsets. The solution is to use `memcpy`, which the compiler will optimize away as able. Fixes #49.

