### PR TITLE
Deferred String Reading

### DIFF
--- a/include/orc/dwarf.hpp
+++ b/include/orc/dwarf.hpp
@@ -18,7 +18,7 @@
 using die_pair = std::tuple<die, attribute_sequence>;
 
 struct dwarf {
-    dwarf(std::uint32_t ofd_index,
+    dwarf(ofd_index ofd_index,
           freader&& s,
           file_details&& details,
           register_dies_callback&& callback);

--- a/include/orc/features.hpp
+++ b/include/orc/features.hpp
@@ -10,4 +10,7 @@
 
 #define ORC_FEATURE(X) (ORC_PRIVATE_FEATURE_ ## X())
 
+#define ORC_PRIVATE_FEATURE_RELEASE() (defined(NDEBUG))
+#define ORC_PRIVATE_FEATURE_DEBUG() (!ORC_PRIVATE_FEATURE_RELEASE())
+
 /**************************************************************************************************/

--- a/include/orc/freader.hpp
+++ b/include/orc/freader.hpp
@@ -1,0 +1,85 @@
+// Copyright 2021 Adobe
+// All Rights Reserved.
+//
+// NOTICE: Adobe permits you to use, modify, and distribute this file in accordance with the terms
+// of the Adobe license agreement accompanying it.
+
+#pragma once
+
+// stdc++
+#include <filesystem>
+#include <istream>
+
+/**************************************************************************************************/
+// very minimal file reader. Uses mmap to bring the file into memory, and subsequently unmaps it
+// when the reader destructs. Doesn't do any kinds of bounds checking while reading (that's a
+// responsibility of the user at this point, but we could change it if it's more valuable to do so
+// here.)
+struct freader {
+    using off_type = std::istream::off_type;
+
+    freader() = default;
+
+    explicit freader(const std::filesystem::path& p);
+
+    // `<=` here because sometimes we jump to one past the end of the buffer right before stopping.
+    explicit operator bool() const { return static_cast<bool>(_buffer) && _p <= _l; }
+
+    std::size_t size() const { return _l - _p; }
+
+    std::size_t tellg() const { return _p - _f; }
+
+    void seekg(std::istream::off_type offset) {
+        assert(*this);
+        _p = _f + offset;
+    }
+
+    void seekg(std::istream::off_type offset, std::ios::seekdir dir) {
+        assert(*this);
+        switch (dir) {
+            case std::ios::beg: {
+                _p = _f + offset;
+            } break;
+            case std::ios::cur: {
+                _p += offset;
+            } break;
+            case std::ios::end: {
+                _p = _f + (size() - offset);
+            } break;
+            default: {
+                // GNU's libstdc++ has an end-of-options marker that the compiler
+                // will complain about as being unhandled here. It should *never*
+                // be used as a valid value for this enumeration.
+                assert(false);
+            } break;
+        }
+    }
+
+    void read(char* p, std::size_t n) {
+        assert(*this);
+        std::memcpy(p, _p, n);
+        _p += n;
+    }
+
+    char get() {
+        assert(*this);
+        return *_p++;
+    }
+
+    std::string_view read_c_string_view() {
+        assert(*this);
+        auto f = _p;
+        for (; *_p; ++_p) {
+        }
+        auto n = _p++ - f;
+        return std::string_view(f, n);
+    }
+
+private:
+    std::shared_ptr<char> _buffer;
+    char* _f{0};
+    char* _p{0};
+    char* _l{0};
+};
+
+/**************************************************************************************************/

--- a/include/orc/hash.hpp
+++ b/include/orc/hash.hpp
@@ -37,7 +37,7 @@ inline std::size_t hash_combine(std::size_t seed, const T& x) {
     // This is the terminating hash_combine call when there's only one item left to hash into the
     // seed. It also serves as the combiner the other routine variant uses to generate its new
     // seed.
-    return (seed ^ x) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    return seed ^= x + 0x9e3779b9 + (seed << 6) + (seed >> 2);
 }
 
 template <class T, class... Args>

--- a/include/orc/macho.hpp
+++ b/include/orc/macho.hpp
@@ -10,6 +10,7 @@
 #include <iostream>
 
 // application
+#include "orc/object_file_registry.hpp"
 #include "orc/parse_file.hpp"
 
 /**************************************************************************************************/
@@ -22,6 +23,6 @@ void read_macho(object_ancestry&& ancestry,
 
 /**************************************************************************************************/
 
-struct dwarf dwarf_from_macho(std::uint32_t ofd_index, register_dies_callback&& callback);
+struct dwarf dwarf_from_macho(ofd_index index, register_dies_callback&& callback);
 
 /**************************************************************************************************/

--- a/include/orc/object_file_registry.hpp
+++ b/include/orc/object_file_registry.hpp
@@ -6,9 +6,80 @@
 
 #pragma once
 
+// stdc++
+#include <array>
+
 // application
-#include "orc/dwarf_structs.hpp"
-#include "orc/parse_file.hpp"
+#include "orc/semantic_type.hpp"
+#include "orc/string_pool.hpp"
+
+/**************************************************************************************************/
+
+struct object_ancestry {
+    std::array<pool_string, 5> _ancestors;
+    std::size_t _count{0};
+
+    auto begin() const { return _ancestors.begin(); }
+    auto end() const { return begin() + _count; }
+
+    auto& back() {
+        assert(_count);
+        return _ancestors[_count];
+    }
+
+    const auto& back() const {
+        assert(_count);
+        return _ancestors[_count];
+    }
+
+    void emplace_back(pool_string&& ancestor) {
+        assert((_count + 1) < _ancestors.size());
+        _ancestors[_count++] = std::move(ancestor);
+    }
+
+    bool operator<(const object_ancestry& rhs) const {
+        if (_count < rhs._count)
+            return true;
+        if (_count > rhs._count)
+            return false;
+        for(size_t i=0; i<_count; ++i) {
+            if (_ancestors[i].view() < rhs._ancestors[i].view())
+                return true;
+            if (_ancestors[i].view() > rhs._ancestors[i].view())
+                return false;
+        }
+        return false;
+    }
+};
+
+/**************************************************************************************************/
+
+enum class arch : std::uint8_t {
+    unknown,
+    x86,
+    x86_64,
+    arm,
+    arm64,
+    arm64_32,
+};
+
+const char* to_string(arch arch); // in dwarf.cpp
+
+/**************************************************************************************************/
+
+struct file_details {
+    enum class format {
+        unknown,
+        macho,
+        ar,
+        fat,
+    };
+    std::size_t _offset{0};
+    format _format{format::unknown};
+    arch _arch{arch::unknown};
+    bool _is_64_bit{false};
+    bool _needs_byteswap{false};
+};
 
 /**************************************************************************************************/
 
@@ -19,15 +90,17 @@ struct object_file_descriptor {
 
 /**************************************************************************************************/
 
-std::size_t object_file_register(object_ancestry&& ancestry, file_details&& details);
+using ofd_index = orc::semantic<std::size_t, struct object_file_register_index>;
 
-const object_file_descriptor& object_file_fetch(std::size_t index);
+ofd_index object_file_register(object_ancestry&& ancestry, file_details&& details);
 
-inline const object_ancestry& object_file_ancestry(std::size_t index) {
+const object_file_descriptor& object_file_fetch(ofd_index index);
+
+inline const object_ancestry& object_file_ancestry(ofd_index index) {
     return object_file_fetch(index)._ancestry;
 }
 
-inline const file_details& object_file_details(std::size_t index) {
+inline const file_details& object_file_details(ofd_index index) {
     return object_file_fetch(index)._details;
 }
 

--- a/include/orc/parse_file.hpp
+++ b/include/orc/parse_file.hpp
@@ -16,77 +16,8 @@
 // application
 #include "orc/dwarf_structs.hpp"
 #include "orc/hash.hpp"
+#include "orc/object_file_registry.hpp"
 #include "orc/string_pool.hpp"
-
-/**************************************************************************************************/
-// very minimal file reader. Uses mmap to bring the file into memory, and subsequently unmaps it
-// when the reader destructs. Doesn't do any kinds of bounds checking while reading (that's a
-// responsibility of the user at this point, but we could change it if it's more valuable to do so
-// here.)
-struct freader {
-    using off_type = std::istream::off_type;
-
-    explicit freader(const std::filesystem::path& p);
-
-    // `<=` here because sometimes we jump to one past the end of the buffer right before stopping.
-    explicit operator bool() const { return static_cast<bool>(_buffer) && _p <= _l; }
-
-    std::size_t size() const { return _l - _p; }
-
-    std::size_t tellg() const { return _p - _f; }
-
-    void seekg(std::istream::off_type offset) {
-        assert(*this);
-        _p = _f + offset;
-    }
-
-    void seekg(std::istream::off_type offset, std::ios::seekdir dir) {
-        assert(*this);
-        switch (dir) {
-            case std::ios::beg: {
-                _p = _f + offset;
-            } break;
-            case std::ios::cur: {
-                _p += offset;
-            } break;
-            case std::ios::end: {
-                _p = _f + (size() - offset);
-            } break;
-            default: {
-                // GNU's libstdc++ has an end-of-options marker that the compiler
-                // will complain about as being unhandled here. It should *never*
-                // be used as a valid value for this enumeration.
-                assert(false);
-            } break;
-        }
-    }
-
-    void read(char* p, std::size_t n) {
-        assert(*this);
-        std::memcpy(p, _p, n);
-        _p += n;
-    }
-
-    char get() {
-        assert(*this);
-        return *_p++;
-    }
-
-    std::string_view read_c_string_view() {
-        assert(*this);
-        auto f = _p;
-        for (; *_p; ++_p) {
-        }
-        auto n = _p++ - f;
-        return std::string_view(f, n);
-    }
-
-private:
-    std::shared_ptr<char> _buffer;
-    char* _f{0};
-    char* _p{0};
-    char* _l{0};
-};
 
 /**************************************************************************************************/
 // temp_seek will move the read pointer of the incoming reader to the specified location, execute
@@ -136,22 +67,6 @@ auto read_exactly(freader& s, std::size_t size, F&& f) {
         return result;
     }
 }
-
-/**************************************************************************************************/
-
-struct file_details {
-    enum class format {
-        unknown,
-        macho,
-        ar,
-        fat,
-    };
-    std::size_t _offset{0};
-    format _format{format::unknown};
-    arch _arch{arch::unknown};
-    bool _is_64_bit{false};
-    bool _needs_byteswap{false};
-};
 
 /**************************************************************************************************/
 

--- a/include/orc/semantic_type.hpp
+++ b/include/orc/semantic_type.hpp
@@ -1,0 +1,41 @@
+// Copyright 2022 Adobe
+// All Rights Reserved.
+//
+// NOTICE: Adobe permits you to use, modify, and distribute this file in accordance with the terms
+// of the Adobe license agreement accompanying it.
+
+#pragma once
+
+// stdc++
+#include <utility>
+
+/**************************************************************************************************/
+
+namespace orc {
+
+/**************************************************************************************************/
+// A semantic type (also known as a phantom type or a named type) is one that is distinguished from
+// other types by its name alone. In other words, the type carries specific meaning in its name.
+
+template <class T, class Meaning>
+struct semantic {
+    constexpr explicit semantic(T const& value) : _value(value) {}
+    constexpr explicit semantic(T&& value) : _value(std::move(value)) {}
+
+    constexpr T& operator*() & { return _value; }
+    constexpr T const& operator*() const& { return _value; }
+    constexpr T&& operator*() && { return std::move(_value); }
+    constexpr const T&& operator*() const&& { return std::move(_value); }
+
+    friend inline bool operator==(const semantic& x, const semantic& y) { return *x == *y; }
+    friend inline bool operator!=(const semantic& x, const semantic& y) { return !(x == y); }
+
+private:
+    T _value{T()};
+};
+
+/**************************************************************************************************/
+
+} // namespace orc
+
+/**************************************************************************************************/

--- a/include/orc/string_pool.hpp
+++ b/include/orc/string_pool.hpp
@@ -49,7 +49,7 @@ struct pool_string {
 
     bool empty() const { return _data == nullptr; }
 
-    explicit operator bool() const { return empty(); }
+    explicit operator bool() const { return !empty(); }
 
     std::string_view view() const {
         // a string_view is empty iff _data is a nullptr

--- a/src/macho.cpp
+++ b/src/macho.cpp
@@ -13,7 +13,6 @@
 // application
 #include "orc/dwarf.hpp"
 #include "orc/mach_types.hpp"
-#include "orc/object_file_registry.hpp"
 #include "orc/settings.hpp"
 #include "orc/str.hpp"
 
@@ -159,7 +158,7 @@ struct mach_header {
 
 /**************************************************************************************************/
 
-dwarf dwarf_from_macho(std::uint32_t ofd_index,
+dwarf dwarf_from_macho(ofd_index ofd_index,
                        freader&& s,
                        file_details&& details,
                        register_dies_callback&& callback) {
@@ -220,8 +219,8 @@ void read_macho(object_ancestry&& ancestry,
                         _callback = std::move(callbacks._register_die)]() mutable {
         ++globals::instance()._object_file_count;
 
-        std::uint32_t ofd_index = object_file_register(std::move(_ancestry), copy(_details));
-        dwarf dwarf = dwarf_from_macho(ofd_index, std::move(_s), std::move(_details),
+        ofd_index index = object_file_register(std::move(_ancestry), copy(_details));
+        dwarf dwarf = dwarf_from_macho(index, std::move(_s), std::move(_details),
                                        std::move(_callback));
 
         dwarf.process_all_dies();
@@ -230,7 +229,7 @@ void read_macho(object_ancestry&& ancestry,
 
 /**************************************************************************************************/
 
-dwarf dwarf_from_macho(std::uint32_t ofd_index, register_dies_callback&& callback) {
+dwarf dwarf_from_macho(ofd_index ofd_index, register_dies_callback&& callback) {
     const auto& entry = object_file_fetch(ofd_index);
     freader s(entry._ancestry.begin()->allocate_path());
 

--- a/src/object_file_registry.cpp
+++ b/src/object_file_registry.cpp
@@ -27,17 +27,17 @@ tbb::concurrent_vector<object_file_descriptor>& obj_registry() {
     
 /**************************************************************************************************/
 
-std::size_t object_file_register(object_ancestry&& ancestry, file_details&& details) {
+ofd_index object_file_register(object_ancestry&& ancestry, file_details&& details) {
     // According to the OneTBB website,
     // "Growing the container does not invalidate any existing iterators or indices."
     // https://spec.oneapi.io/versions/latest/elements/oneTBB/source/containers/concurrent_vector_cls.html
 
     auto result = obj_registry().emplace_back(object_file_descriptor{std::move(ancestry), std::move(details)});
-    return std::distance(obj_registry().begin(), result);
+    return ofd_index(std::distance(obj_registry().begin(), result));
 }
 
-const object_file_descriptor& object_file_fetch(std::size_t index) {
-    return obj_registry()[index];
+const object_file_descriptor& object_file_fetch(ofd_index index) {
+    return obj_registry()[*index];
 }
 
 /**************************************************************************************************/

--- a/src/orc.cpp
+++ b/src/orc.cpp
@@ -106,12 +106,12 @@ bool type_equivalent(const attribute& x, const attribute& y) {
     // types are pretty convoluted, so we pull their comparison out here in an effort to
     // keep it all in a developer's head.
 
-    if (x.has(attribute_value::type::reference) && y.has(attribute_value::type::reference) &&
+    if (x.has(attribute_value_type::reference) && y.has(attribute_value_type::reference) &&
         x.reference() == y.reference()) {
         return true;
     }
 
-    if (x.has(attribute_value::type::string) && y.has(attribute_value::type::string) &&
+    if (x.has(attribute_value_type::string) && y.has(attribute_value_type::string) &&
         x.string_hash() == y.string_hash()) {
         return true;
     }
@@ -327,7 +327,7 @@ attribute_sequence fetch_attributes_for_die(const die& d) {
 
     auto [die, attributes] = dwarf.fetch_one_die(d._debug_info_offset);
     assert(die._tag == d._tag);
-    assert(die._arch == d._arch);
+    assert(object_file_details(die._ofd_index)._arch == object_file_details(d._ofd_index)._arch);
     assert(die._has_children == d._has_children);
     assert(die._debug_info_offset == d._debug_info_offset);
     return std::move(attributes);


### PR DESCRIPTION
We're spending a lot of time reading strings from DWARF's `debug_str` section, without any guarantees that these strings will be necessary during DIE processing. This PR defers string reading until the string's first use.