### PR TITLE
Add support for relative output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,8 +56,8 @@ if (NOT TARGET TBB::tbb)
     # Turning strict off causes warnings to not be errors for the TBB sources, which works for us.
     set(TBB_STRICT OFF)
     set(BUILD_SHARED_LIBS OFF) # See https://github.com/oneapi-src/oneTBB/issues/297#issuecomment-772759422
-    add_compile_options(-Wno-error)
     FetchContent_MakeAvailable(tbb)
+    target_compile_options(tbb PUBLIC -Wno-error)
 endif()
 
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -76,6 +76,11 @@ add_executable(orc::orc ALIAS orc_orc)
 
 set_target_properties(orc_orc PROPERTIES OUTPUT_NAME "orc")
 
+if (PROJECT_IS_TOP_LEVEL)
+    target_compile_options(orc_orc PRIVATE -Wall -Werror)
+    set_target_properties(orc_orc PROPERTIES XCODE_GENERATE_SCHEME ON)
+endif()
+
 target_link_libraries(orc_orc
     PRIVATE
         stlab::stlab
@@ -87,11 +92,6 @@ target_include_directories(orc_orc
     PRIVATE
         ${PROJECT_SOURCE_DIR}/include
 )
-
-if (PROJECT_IS_TOP_LEVEL)
-    target_compile_options(orc_orc PRIVATE -Wall -Werror)
-    set_target_properties(orc_orc PROPERTIES XCODE_GENERATE_SCHEME ON)
-endif()
 
 # This is the end of the ORC executable definition
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ if (NOT TARGET TBB::tbb)
     # Turning strict off causes warnings to not be errors for the TBB sources, which works for us.
     set(TBB_STRICT OFF)
     set(BUILD_SHARED_LIBS OFF) # See https://github.com/oneapi-src/oneTBB/issues/297#issuecomment-772759422
+    add_compile_options(-Wno-error)
     FetchContent_MakeAvailable(tbb)
 endif()
 

--- a/_orc-config
+++ b/_orc-config
@@ -70,6 +70,16 @@ standalone_mode = false
 
 # output_file = "out.txt"
 
+# If defined, ORC will log output at the file location of the liner output file,
+# which must be specified with `-o` or `--output` on the command line. For example,
+# if the the output file is `path\to\my\binary` and this is set to `out.txt`, ORC 
+# will write its output to `path\to\my\binary.out.txt`.
+# 
+# output_file should NOT be specified if this is used.
+# (Normal stream output is unaffected by `relative_output_file`.)
+
+# relative_output_file = "out.txt"
+
 # `print_object_file_list`, when true, will print the list of object files ORC would otherwise
 # process, and then it exits without failure.
 #

--- a/include/orc/orc.hpp
+++ b/include/orc/orc.hpp
@@ -41,7 +41,8 @@ private:
 
 std::ostream& operator<<(std::ostream& s, const odrv_report& x);
 
-bool filter_print_report(std::ostream& s, const odrv_report& report);
+// Return `true` if an ODRV
+bool filter_report(const odrv_report& report);
 
 /**************************************************************************************************/
 

--- a/include/orc/orc.hpp
+++ b/include/orc/orc.hpp
@@ -41,6 +41,8 @@ private:
 
 std::ostream& operator<<(std::ostream& s, const odrv_report& x);
 
+bool filter_print_report(std::ostream& s, const odrv_report& report);
+
 /**************************************************************************************************/
 
 std::vector<odrv_report> orc_process(const std::vector<std::filesystem::path>&);

--- a/include/orc/settings.hpp
+++ b/include/orc/settings.hpp
@@ -43,6 +43,7 @@ struct settings {
     bool _parallel_processing{true};
     bool _show_progress{false};
     bool _filter_redundant{true};
+    std::string _relative_output_file;
 };
 
 /**************************************************************************************************/

--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -49,7 +49,7 @@ std::uint32_t form_length(dw::form f, freader& s) {
             assert(false);
             return 0; // TODO: read NTSB from s
         case dw::form::block:
-            return (std::uint32_t)leb_block();
+            return static_cast<std::uint32_t>(leb_block());
         case dw::form::block1:
             // for block1, block2, and block4, we read the N-byte prefix, and then send back
             // its value as the length of the form. This causes the passover to skip over the
@@ -90,7 +90,7 @@ std::uint32_t form_length(dw::form f, freader& s) {
         case dw::form::sec_offset:
             return length_size_k;
         case dw::form::exprloc:
-            return (std::uint32_t)leb_block();
+            return static_cast<std::uint32_t>(leb_block());
         case dw::form::flag_present:
             return 0;
         case dw::form::strx:
@@ -780,7 +780,7 @@ attribute_value dwarf::implementation::evaluate_exprloc(std::uint32_t expression
         result.passover();
     } else {
         assert(!stack.empty());
-        result.sint((std::int32_t)stack.back());
+        result.sint(static_cast<std::int32_t>(stack.back()));
     }
 
     return result;
@@ -818,7 +818,7 @@ attribute_value dwarf::implementation::process_form(const attribute& attr,
         } break;
         case dw::form::exprloc: {
             read_exactly(_s, read_uleb(),
-                         [&](auto expr_size) { result = evaluate_exprloc((std::uint32_t)expr_size); });
+                         [&](auto expr_size) { result = evaluate_exprloc(static_cast<std::uint32_t>(expr_size)); });
         } break;
         case dw::form::addr: {
             result.uint(read64());
@@ -827,16 +827,16 @@ attribute_value dwarf::implementation::process_form(const attribute& attr,
             result.reference(read32());
         } break;
         case dw::form::ref1: {
-            result.reference(std::uint32_t(cu_offset + read8()));
+            result.reference(static_cast<std::uint32_t>(cu_offset + read8()));
         } break;
         case dw::form::ref2: {
-            result.reference(std::uint32_t(cu_offset + read16()));
+            result.reference(static_cast<std::uint32_t>(cu_offset + read16()));
         } break;
         case dw::form::ref4: {
-            result.reference(std::uint32_t(cu_offset + read32()));
+            result.reference(static_cast<std::uint32_t>(cu_offset + read32()));
         } break;
         case dw::form::ref8: {
-            result.reference(std::uint32_t(cu_offset + read64()));
+            result.reference(static_cast<std::uint32_t>(cu_offset + read64()));
         } break;
         case dw::form::data1: {
             result.uint(read8());
@@ -927,14 +927,14 @@ die_pair dwarf::implementation::abbreviation_to_die(std::size_t die_address, pro
     die die;
     attribute_sequence attributes;
 
-    die._debug_info_offset = std::uint32_t(die_address - _debug_info._offset);
+    die._debug_info_offset = static_cast<std::uint32_t>(die_address - _debug_info._offset);
     die._arch = _details._arch;
 
     std::size_t abbrev_code = read_uleb();
 
     if (abbrev_code == 0) return std::make_tuple(std::move(die), std::move(attributes));
 
-    auto& a = find_abbreviation((std::uint32_t)abbrev_code);
+    auto& a = find_abbreviation(static_cast<std::uint32_t>(abbrev_code));
 
     die._tag = a._tag;
     die._has_children = a._has_children;

--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -49,7 +49,7 @@ std::uint32_t form_length(dw::form f, freader& s) {
             assert(false);
             return 0; // TODO: read NTSB from s
         case dw::form::block:
-            return leb_block();
+            return (std::uint32_t)leb_block();
         case dw::form::block1:
             // for block1, block2, and block4, we read the N-byte prefix, and then send back
             // its value as the length of the form. This causes the passover to skip over the
@@ -90,7 +90,7 @@ std::uint32_t form_length(dw::form f, freader& s) {
         case dw::form::sec_offset:
             return length_size_k;
         case dw::form::exprloc:
-            return leb_block();
+            return (std::uint32_t)leb_block();
         case dw::form::flag_present:
             return 0;
         case dw::form::strx:
@@ -704,7 +704,7 @@ pool_string dwarf::implementation::die_identifier(const die& d,
 /**************************************************************************************************/
 
 attribute_value dwarf::implementation::evaluate_exprloc(std::uint32_t expression_size) {
-    std::vector<std::int32_t> stack;
+    std::vector<std::int64_t> stack;
     const auto end = _s.tellg() + expression_size;
 
     // There are some exprlocs that cannot be deciphered, probably because we don't have as much
@@ -780,7 +780,7 @@ attribute_value dwarf::implementation::evaluate_exprloc(std::uint32_t expression
         result.passover();
     } else {
         assert(!stack.empty());
-        result.sint(stack.back());
+        result.sint((std::int32_t)stack.back());
     }
 
     return result;
@@ -818,7 +818,7 @@ attribute_value dwarf::implementation::process_form(const attribute& attr,
         } break;
         case dw::form::exprloc: {
             read_exactly(_s, read_uleb(),
-                         [&](auto expr_size) { result = evaluate_exprloc(expr_size); });
+                         [&](auto expr_size) { result = evaluate_exprloc((std::uint32_t)expr_size); });
         } break;
         case dw::form::addr: {
             result.uint(read64());
@@ -827,16 +827,16 @@ attribute_value dwarf::implementation::process_form(const attribute& attr,
             result.reference(read32());
         } break;
         case dw::form::ref1: {
-            result.reference(cu_offset + read8());
+            result.reference(std::uint32_t(cu_offset + read8()));
         } break;
         case dw::form::ref2: {
-            result.reference(cu_offset + read16());
+            result.reference(std::uint32_t(cu_offset + read16()));
         } break;
         case dw::form::ref4: {
-            result.reference(cu_offset + read32());
+            result.reference(std::uint32_t(cu_offset + read32()));
         } break;
         case dw::form::ref8: {
-            result.reference(cu_offset + read64());
+            result.reference(std::uint32_t(cu_offset + read64()));
         } break;
         case dw::form::data1: {
             result.uint(read8());
@@ -927,14 +927,14 @@ die_pair dwarf::implementation::abbreviation_to_die(std::size_t die_address, pro
     die die;
     attribute_sequence attributes;
 
-    die._debug_info_offset = die_address - _debug_info._offset;
+    die._debug_info_offset = std::uint32_t(die_address - _debug_info._offset);
     die._arch = _details._arch;
 
     std::size_t abbrev_code = read_uleb();
 
     if (abbrev_code == 0) return std::make_tuple(std::move(die), std::move(attributes));
 
-    auto& a = find_abbreviation(abbrev_code);
+    auto& a = find_abbreviation((std::uint32_t)abbrev_code);
 
     die._tag = a._tag;
     die._has_children = a._has_children;

--- a/src/macho.cpp
+++ b/src/macho.cpp
@@ -220,7 +220,7 @@ void read_macho(object_ancestry&& ancestry,
                         _callback = std::move(callbacks._register_die)]() mutable {
         ++globals::instance()._object_file_count;
 
-        std::uint32_t ofd_index = (std::uint32_t) object_file_register(std::move(_ancestry), copy(_details));
+        std::uint32_t ofd_index = static_cast<std::uint32_t>(object_file_register(std::move(_ancestry), copy(_details)));
         dwarf dwarf = dwarf_from_macho(ofd_index, std::move(_s), std::move(_details),
                                        std::move(_callback));
 

--- a/src/macho.cpp
+++ b/src/macho.cpp
@@ -220,7 +220,7 @@ void read_macho(object_ancestry&& ancestry,
                         _callback = std::move(callbacks._register_die)]() mutable {
         ++globals::instance()._object_file_count;
 
-        std::uint32_t ofd_index = object_file_register(std::move(_ancestry), copy(_details));
+        std::uint32_t ofd_index = (std::uint32_t) object_file_register(std::move(_ancestry), copy(_details));
         dwarf dwarf = dwarf_from_macho(ofd_index, std::move(_s), std::move(_details),
                                        std::move(_callback));
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,14 +75,7 @@ void open_output_file(const std::string& a, const std::string& b)
     if (!a.empty()) {
         path = a + '.' + b;
     }
-    try {
-        globals::instance()._fp.open(path);
-    }
-    catch (const std::exception& e) {
-        cout_safe([&](auto& s){
-            s << "warning: Could not open output file: " << path << "\n";
-        });
-    }
+    globals::instance()._fp.open(path);
 }
 
 /**************************************************************************************************/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -508,12 +508,13 @@ int main(int argc, char** argv) try {
         throw std::runtime_error("ORC could not find files to process");
     }
 
-    // Count the ODRVs. FIXME See `filter_print_report` for code that needs refactoring.
-    // The stream_to_nowhere is a temporary work-around.
-    for (const auto& report : orc_process(file_list)) {
-        std::stringstream stream_to_nowhere;
+    std::vector<odrv_report> reports = orc_process(file_list);
+    std::vector<odrv_report> violations;
 
-        if (filter_print_report(stream_to_nowhere, report)) {
+    for (const auto& report : reports) {
+        if (filter_report(report)) {
+            violations.push_back(report);
+
             // Administrivia
             ++globals::instance()._odrv_count;
 
@@ -523,8 +524,9 @@ int main(int argc, char** argv) try {
             }
         }
     }
+    assert(globals::instance()._odrv_count == violations.size());
 
-    for (const auto& report : orc_process(file_list)) {
+    for (const auto& report : violations) {
         cout_safe([&](auto& s){
             s << report;   // important to NOT add the '\n', because lots of reports are empty, and it creates a lot of blank lines
         });

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,8 +75,6 @@ void open_output_file(const std::string& a, const std::string& b)
     if (!a.empty()) {
         path = a + '.' + b;
     }
-    std::cout << "open output file\n";
-    std::cout << "path:" << path << "\n";
     try {
         globals::instance()._fp.open(path);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -508,6 +508,22 @@ int main(int argc, char** argv) try {
         throw std::runtime_error("ORC could not find files to process");
     }
 
+    // Count the ODRVs. FIXME See `filter_print_report` for code that needs refactoring.
+    // The stream_to_nowhere is a temporary work-around.
+    for (const auto& report : orc_process(file_list)) {
+        std::stringstream stream_to_nowhere;
+
+        if (filter_print_report(stream_to_nowhere, report)) {
+            // Administrivia
+            ++globals::instance()._odrv_count;
+
+            if (settings::instance()._max_violation_count > 0 &&
+                globals::instance()._odrv_count >= settings::instance()._max_violation_count) {
+                throw std::runtime_error("ODRV limit reached");
+            }
+        }
+    }
+
     for (const auto& report : orc_process(file_list)) {
         cout_safe([&](auto& s){
             s << report;   // important to NOT add the '\n', because lots of reports are empty, and it creates a lot of blank lines

--- a/src/orc.cpp
+++ b/src/orc.cpp
@@ -373,17 +373,8 @@ std::string odrv_report::category() const {
 }
 
 /**************************************************************************************************/
-// FIXME This just needs refactoring. This code originally:
-// 1. filters
-// 2. output
-// 3. counts numeber of ODRVs
-// All inside a `operator<<`.
-// This pulls things part just a little bit so we can compute the number of ODRVs correctly,
-// but still needs cleanup.
-
-bool filter_print_report(std::ostream& s, const odrv_report& report)
+bool filter_report(const odrv_report& report)
 {
-    const std::string_view& symbol = report._symbol;
     std::string odrv_category = report.category();
 
     // Decide if we should report or ignore.
@@ -399,9 +390,17 @@ bool filter_print_report(std::ostream& s, const odrv_report& report)
         do_report = sorted_has(settings._violation_report, odrv_category);
     }
 
-    if (!do_report) return false;
+    return do_report;
+}
 
-    // Output the report
+
+/**************************************************************************************************/
+
+std::ostream& operator<<(std::ostream& s, const odrv_report& report) 
+{    
+    const std::string_view& symbol = report._symbol;
+    std::string odrv_category = report.category();
+
     s << problem_prefix() << ": ODRV (" << odrv_category << "); conflict in `"
       << (symbol.data() ? demangle(symbol.data()) : "<unknown>") << "`\n";
     for (const auto& entry : report.conflict_map()) {
@@ -409,14 +408,6 @@ bool filter_print_report(std::ostream& s, const odrv_report& report)
     }
     s << "\n";
 
-    return true;
-}
-
-
-/**************************************************************************************************/
-
-std::ostream& operator<<(std::ostream& s, const odrv_report& report) {
-    filter_print_report(s, report);
     return s;
 }
 

--- a/src/string_pool.cpp
+++ b/src/string_pool.cpp
@@ -32,7 +32,7 @@ namespace {
 
 /**************************************************************************************************/
 
-std::size_t string_view_hash(std::string_view s) { return orc::murmur3_64(s.data(), (std::uint32_t) s.length()); }
+std::size_t string_view_hash(std::string_view s) { return orc::murmur3_64(s.data(), static_cast<std::uint32_t>(s.length())); }
 
 /**************************************************************************************************/
 

--- a/src/string_pool.cpp
+++ b/src/string_pool.cpp
@@ -32,7 +32,7 @@ namespace {
 
 /**************************************************************************************************/
 
-std::size_t string_view_hash(std::string_view s) { return orc::murmur3_64(s.data(), s.length()); }
+std::size_t string_view_hash(std::string_view s) { return orc::murmur3_64(s.data(), (std::uint32_t) s.length()); }
 
 /**************************************************************************************************/
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Writes the ORC output at the same location as the linker output.


See #53. Fixes #53.

Also addresses: 
* due to a toolchain upgrade - unspecified casts.
* long standing bug where writing to a file would double the ODRV count
