### PR TITLE
Improve expression evaluator, (non)fatal attribute evaluation, and ORC dogfood

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,27 +73,37 @@ add_executable(orc_orc
     ${HEADER_FILES}
 )
 add_executable(orc::orc ALIAS orc_orc)
-
 set_target_properties(orc_orc PROPERTIES OUTPUT_NAME "orc")
 
-if (PROJECT_IS_TOP_LEVEL)
-    target_compile_options(orc_orc PRIVATE -Wall -Werror)
-    set_target_properties(orc_orc PROPERTIES XCODE_GENERATE_SCHEME ON)
-endif()
-
-target_link_libraries(orc_orc
-    PRIVATE
-        stlab::stlab
-        TBB::tbb
-        tomlplusplus::tomlplusplus
+add_executable(orc_dogfood
+    ${SRC_FILES}
+    ${HEADER_FILES}
 )
+add_executable(orc::dogfood ALIAS orc_dogfood)
+set_target_properties(orc_dogfood PROPERTIES OUTPUT_NAME "orc_dogfood")
 
-target_include_directories(orc_orc
-    PRIVATE
-        ${PROJECT_SOURCE_DIR}/include
-)
+foreach(_TARGET_NAME IN ITEMS orc_orc orc_dogfood)
 
-# This is the end of the ORC executable definition
+    if (PROJECT_IS_TOP_LEVEL)
+        target_compile_options(${_TARGET_NAME} PRIVATE -Wall -Werror)
+        set_target_properties(${_TARGET_NAME} PROPERTIES XCODE_GENERATE_SCHEME ON)
+    endif()
+
+    target_link_libraries(${_TARGET_NAME}
+        PRIVATE
+            stlab::stlab
+            TBB::tbb
+            tomlplusplus::tomlplusplus
+    )
+
+    target_include_directories(${_TARGET_NAME}
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+    )
+
+endforeach()
+
+# This is the end of the ORC executable(s) definition
 
 file(GLOB TEST_SRC_FILES CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/test/src/*.cpp)
 list(REMOVE_ITEM SRC_FILES ${PROJECT_SOURCE_DIR}/src/main.cpp)
@@ -130,12 +140,17 @@ if (NOT PROJECT_IS_TOP_LEVEL)
     set(ORC_HELPERS ${ORC_HELPERS} PARENT_SCOPE)
 endif()
 
+include(${ORC_HELPERS})
+
+# The dogfood target is specifically to run ORC over itself.
+if (CMAKE_GENERATOR MATCHES "Xcode")
+    link_via_orc(orc_dogfood)
+endif()
+
 # These are example apps that uses ORC as its linker. We can add as many of these as necessary to
 # test out the tool.
 
 if (ORC_BUILD_EXAMPLES)
-
-    include(${ORC_HELPERS})
 
     ##### example app: vtable
 

--- a/include/orc/features.hpp
+++ b/include/orc/features.hpp
@@ -10,4 +10,12 @@
 
 #define ORC_FEATURE(X) (ORC_PRIVATE_FEATURE_ ## X())
 
+#ifndef NDEBUG
+    #define ORC_PRIVATE_FEATURE_DEBUG() 1
+    #define ORC_PRIVATE_FEATURE_RELEASE() 0
+#else
+    #define ORC_PRIVATE_FEATURE_DEBUG() 0
+    #define ORC_PRIVATE_FEATURE_RELEASE() 1
+#endif // !defined(NDEBUG)
+
 /**************************************************************************************************/

--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -192,11 +192,8 @@ struct file_name {
 std::size_t die_hash(const die& d, const attribute_sequence& attributes) {
     bool is_declaration =
         attributes.has_uint(dw::at::declaration) && attributes.uint(dw::at::declaration) == 1;
-    return orc::hash_combine(0,
-                             static_cast<std::size_t>(d._arch),
-                             static_cast<std::size_t>(d._tag),
-                             d._path.hash(),
-                             is_declaration);
+    return orc::hash_combine(0, static_cast<std::size_t>(d._arch), static_cast<std::size_t>(d._tag),
+                             d._path.hash(), is_declaration);
 };
 
 /**************************************************************************************************/
@@ -720,16 +717,14 @@ attribute_value dwarf::implementation::evaluate_exprloc(std::uint32_t expression
     // but is supported by both GCC and clang. It makes the below *far* more readable, but if
     // we need to pull it out, we can.
 
-    auto stack_pop = [&_stack = stack]{
+    auto stack_pop = [&_stack = stack] {
         assert(!_stack.empty());
         auto result = _stack.back();
         _stack.pop_back();
         return result;
     };
 
-    auto stack_push = [&_stack = stack](auto value){
-        _stack.push_back(value);
-    };
+    auto stack_push = [&_stack = stack](auto value) { _stack.push_back(value); };
 
     // REVISIT (fosterbrereton) : The DWARF specification describes a
     // multi-register stack machine. This implementation is anything but.
@@ -861,7 +856,7 @@ attribute_value dwarf::implementation::process_form(const attribute& attr,
     const auto cu_offset = _cu_address - debug_info_offset;
     attribute_value result;
 
-    auto set_passover_result = [&]{
+    auto set_passover_result = [&] {
         result.passover();
         auto size = form_length(form, _s);
         _s.seekg(size, std::ios::cur);
@@ -874,8 +869,7 @@ attribute_value dwarf::implementation::process_form(const attribute& attr,
             return;
         }
         auto length = (_impl->*length_fn)();
-        read_exactly(_s, length,
-                     [&](auto length) { result = evaluate_exprloc(length); });
+        read_exactly(_s, length, [&](auto length) { result = evaluate_exprloc(length); });
     };
 
     /*
@@ -900,8 +894,9 @@ attribute_value dwarf::implementation::process_form(const attribute& attr,
             result.string(read_debug_str(read32()));
         } break;
         case dw::form::exprloc: {
-            read_exactly(_s, read_uleb(),
-                         [&](auto expr_size) { result = evaluate_exprloc(static_cast<std::uint32_t>(expr_size)); });
+            read_exactly(_s, read_uleb(), [&](auto expr_size) {
+                result = evaluate_exprloc(static_cast<std::uint32_t>(expr_size));
+            });
         } break;
         case dw::form::addr: {
             result.uint(read64());

--- a/src/dwarf_structs.cpp
+++ b/src/dwarf_structs.cpp
@@ -160,6 +160,7 @@ bool nonfatal_attribute(dw::at at) {
             dw::at::call_line,
             dw::at::call_origin,
             dw::at::call_return_pc,
+            dw::at::call_value,
             dw::at::containing_type,
             dw::at::decl_column,
             dw::at::decl_file,
@@ -171,7 +172,7 @@ bool nonfatal_attribute(dw::at at) {
             // assume this attribute is of constant form, this is the size of the function. If two
             // or more functions with the same name have different high_pc values, their sizes are
             // different, which means their definitions are going to be different, and that's an
-            // ODRV.
+            // ODRV. Thus, dw::at::high_pc is a fatal attribute.
             // dw::at::high_pc,
             dw::at::location,
             dw::at::low_pc,


### PR DESCRIPTION
This PR does a handful of things:

## Improved expression evaluation

Some libraries have been found that use new DWARF 5 constructs (`DW_OP_stack_value`), as well as more complex uses of the DWARF form expression evaluator. This PR improves upon ORC's ability to evaluate DWARF form expressions. This will fix some errors where the attribute is showing as `<unhandled>`, and may result in an ODRV false positives that read thusly (note the `<unhandled>` value for the first `data_member_location`):

```
warning: ODRV (member:data_member_location); conflict in `NSURL::_baseURL`
    within: libAppAuth.a:
    within: OIDAuthState+IOS.o:
        definition location: /path/to/NSURL.h:22
        name: _baseURL
        type: NSURL*
        data_member_location: <unhandled>
        accessibility: 2 (0x2)

    within: libGTMAppAuth.a:
    within: GTMAppAuthFetcherAuthorization.o:
        definition location: /path/to/NSURL.h:22
        name: _baseURL
        type: NSURL*
        data_member_location: 0 (0x0)
        accessibility: 2 (0x2)
```
## Improved expression evaluation skipping

We have been identifying nonfatal attributes for some time now. This PR includes an optimization where, for some attributes, the value is passed over when we know it is not necessary for detecting for ODRVs.

## Dogfood build

The CMake project is modified to add an `orc_dogfood` target. It is identical to the `orc_orc` target, except ORC is passed over the dogfood target during link time. This ensures that ORC itself has no ODR violations (at least as far as the tool can detect them.) This addresses a comment made in #20.