### PR TITLE
Fix a few compilation issues (clang 13)

### DIFF
--- a/include/orc/memory.hpp
+++ b/include/orc/memory.hpp
@@ -6,6 +6,9 @@
 
 #pragma once
 
+// stdc++
+#include <cstring>
+
 // application
 #include "orc/features.hpp"
 

--- a/include/orc/string_pool.hpp
+++ b/include/orc/string_pool.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 // stdc++
+#include <cassert>
 #include <ostream>
 #include <string>
 #include <string_view>

--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -1020,7 +1020,7 @@ bool dwarf::implementation::skip_die(die& d, const attribute_sequence& attribute
         // To determine that, we'll jump to the reference, grab the abbreviation code,
         // and see how many attributes it should have.
         auto reference = attributes.reference(dw::at::type);
-        bool empty = temp_seek(_s, _debug_info._offset + reference, std::ios::seekdir::beg, [&] {
+        bool empty = temp_seek(_s, _debug_info._offset + reference, std::ios::beg, [&] {
             auto abbrev_code = read_uleb();
             const auto& abbrev = find_abbreviation(abbrev_code);
             return abbrev._attributes.empty();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 
 // stdc++
 #include <array>
+#include <csignal>
 #include <cxxabi.h>
 #include <filesystem>
 #include <fstream>

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -66,7 +66,7 @@ auto& toml_out() {
 
 /**************************************************************************************************/
 
-namespace log {
+namespace logging {
 
 /**************************************************************************************************/
 
@@ -433,7 +433,7 @@ void run_battery_test(const std::filesystem::path& home) {
     const bool skip_test = settings["orc_test_flags"]["disable"].value_or(false);
 
     if (skip_test) {
-        log::notice("test disabled");
+        logging::notice("test disabled");
         return;
     }
 
@@ -446,7 +446,7 @@ void run_battery_test(const std::filesystem::path& home) {
 
     auto expected_odrvs = derive_expected_odrvs(home, settings);
     if (expected_odrvs.empty()) {
-        log::notice("Found no expected ODRVs for this test", test_name);
+        logging::notice("Found no expected ODRVs for this test", test_name);
     }
 
     auto object_files = compile_compilation_units(home, settings, compilation_units);
@@ -553,10 +553,10 @@ int main(int argc, char** argv) try {
 
     return EXIT_SUCCESS;
 } catch (const std::exception& error) {
-    log::error(error.what(), "Fatal error");
+    logging::error(error.what(), "Fatal error");
     return EXIT_FAILURE;
 } catch (...) {
-    log::error("unknown", "Fatal error");
+    logging::error("unknown", "Fatal error");
     return EXIT_FAILURE;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR fixes a few compilation errors I had when compiling `orc` with Clang 13.0:

- missing includes
- `std::ios_base::beg` prefixed with enum name
- namespace `log` conflicting with `log` from `math.h`

## How Has This Been Tested?

The code now compiles with clang 13.0, but I haven't checked if it still compiles with Xcode. The `orc_test` executable runs correctly (but fails because of incorrect binary file format of course).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
