### PR TITLE
Handle the endian byte swap inline when reading atomic values via `read_pod`

### DIFF
--- a/include/orc/parse_file.hpp
+++ b/include/orc/parse_file.hpp
@@ -157,6 +157,8 @@ struct file_details {
 
 template <typename T>
 void endian_swap(T& c) {
+    if constexpr (sizeof(T) == 1) return;
+
     char* first = reinterpret_cast<char*>(&c);
     char* last = first + sizeof(T);
     while (first != last) {
@@ -177,10 +179,24 @@ T read_pod(freader& s) {
 
 template <>
 inline bool read_pod(freader& s) {
-    char x;
-    s.read(reinterpret_cast<char*>(&x), 1);
-    return x ? true : false;
+    return read_pod<char>(s) != 0;
 }
+
+template <typename T>
+T read_pod(freader& s, bool byteswap) {
+    T x;
+    s.read(reinterpret_cast<char*>(&x), sizeof(T));
+    if (byteswap) {
+        endian_swap(x);
+    }
+    return x;
+}
+
+template <>
+inline bool read_pod(freader& s, bool) {
+    return read_pod<char>(s) != 0;
+}
+
 /**************************************************************************************************/
 
 std::uint32_t uleb128(freader& s);

--- a/src/parse_file.cpp
+++ b/src/parse_file.cpp
@@ -65,11 +65,7 @@ file_details detect_file(freader& s) {
         }
 
         if (result._format == file_details::format::macho) {
-            std::uint32_t cputype{0};
-            s.read(reinterpret_cast<char*>(&cputype), sizeof(cputype));
-            if (result._needs_byteswap) {
-                endian_swap(cputype);
-            }
+            const auto cputype = read_pod<std::uint32_t>(s, result._needs_byteswap);
             assert(((cputype & CPU_ARCH_ABI64) != 0) == result._is_64_bit);
             if (cputype == CPU_TYPE_X86) {
                 result._arch = arch::x86;


### PR DESCRIPTION
This is a small cleanup PR. There are many cases where we read an individual value (`std::uint32_t`) via `read_pod`, and after the read perform a byte-swap on it if the on-disk endianness doesn't match the current architecture's. This change adds an implementation of `read_pod` that takes a boolean where, if true, performs the endian swap within `read_pod` itself. Example:

Old:
```c++
std::uint32_t cputype{read_pod<std::uint32_t>(s)};
if (result._needs_byteswap) {
    endian_swap(cputype);
}
```
New:
```c++
const auto cputype = read_pod<std::uint32_t>(s, result._needs_byteswap);
```




Note that there is still a byteswap-free implementation of `read_pod`, as we use it to read aggregate data structures whole-hog, then go back and byteswap the individual values later.