### PR TITLE
Tagged Release Action

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -28,7 +28,7 @@ jobs:
           tar -zcvf orc-${{ env.NEXT_TAG }}-macos.tgz build/Release/orc
       - name: ✍️ Release
         uses: softprops/action-gh-release@v1
-        generate_release_notes: true
         with:
+          generate_release_notes: true
           files:
             orc-${{ env.NEXT_TAG }}-macos.tgz

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -3,6 +3,8 @@ on:
   push:
     tags:
       - "v*.*.*"
+permissions:
+  contents: write
 jobs:
   build:
     runs-on: macos-latest

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -5,11 +5,11 @@ on:
       - "v*.*.*"
 permissions:
   contents: write
-env:
-  artifact_name: orc-${{github.ref_name}}-${{runner.os}}-${{runner.arch}}.tgz
 jobs:
   release:
     runs-on: macos-latest
+    env:
+      artifact_name: orc-${{github.ref_name}}-${{runner.os}}-${{runner.arch}}.tgz
     steps:
       - name: 🐍 Python setup
         uses: actions/setup-python@v2

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -8,8 +8,6 @@ permissions:
 jobs:
   release:
     runs-on: macos-latest
-    env:
-      artifact_name: orc-${{github.ref_name}}-${{runner.os}}-${{runner.arch}}.tgz
     steps:
       - name: 🐍 Python setup
         uses: actions/setup-python@v2
@@ -27,10 +25,10 @@ jobs:
           xcodebuild -json -project ./build/orc.xcodeproj -scheme orc_orc -configuration Release -hideShellScriptEnvironment
       - name: 🗜️ Compress binary
         run: |
-          tar -zcvf ${{env.artifact_name}} build/Release/orc
+          tar -zcvf orc-${{github.ref_name}}-${{runner.os}}-${{runner.arch}}.tgz build/Release/orc
       - name: ✍️ Release archive
         uses: softprops/action-gh-release@v1
         with:
           generate_release_notes: true
           files:
-            ${{env.artifact_name}}
+            orc-${{github.ref_name}}-${{runner.os}}-${{runner.arch}}.tgz

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -6,25 +6,29 @@ on:
 permissions:
   contents: write
 jobs:
-  build:
+  release:
     runs-on: macos-latest
     steps:
-      - name: 🐍 setup
+      - name: 🐍 Setup
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - name: ⬇️ sources
+      - name: ⬇️ Sources
         uses: actions/checkout@v3
-      - name: 🏗️ project files
+      - name: 🏗️ Project files
         run: |
           mkdir build
           cd build
           cmake --log-level=WARNING -DORC_BUILD_EXAMPLES=0 -GXcode ..
-      - name: 🛠️ orc release
+      - name: 🛠️ ORC
         run: |
           xcodebuild -json -project ./build/orc.xcodeproj -scheme orc_orc -configuration Release -hideShellScriptEnvironment
+      - name: ✏️ Compress
+        run: |
+          tar -zcvf orc-${{ env.NEXT_TAG }}-macos.tgz build/Release/orc
       - name: ✍️ Release
         uses: softprops/action-gh-release@v1
+        generate_release_notes: true
         with:
           files:
-            build/Release/orc
+            orc-${{ env.NEXT_TAG }}-macos.tgz

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -1,0 +1,28 @@
+name: Tagged Release
+on:
+  push:
+    tags:
+      - "v*.*.*"
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: 🐍 setup
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: ⬇️ sources
+        uses: actions/checkout@v3
+      - name: 🏗️ project files
+        run: |
+          mkdir build
+          cd build
+          cmake --log-level=WARNING -DORC_BUILD_EXAMPLES=0 -GXcode ..
+      - name: 🛠️ orc release
+        run: |
+          xcodebuild -json -project ./build/orc.xcodeproj -scheme orc_orc -configuration Release -hideShellScriptEnvironment
+      - name: ✍️ Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files:
+            build/Release/orc

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -5,30 +5,32 @@ on:
       - "v*.*.*"
 permissions:
   contents: write
+env:
+  artifact_name: orc-${{github.ref_name}}-${{runner.os}}-${{runner.arch}}.tgz
 jobs:
   release:
     runs-on: macos-latest
     steps:
-      - name: 🐍 Setup
+      - name: 🐍 Python setup
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - name: ⬇️ Sources
+      - name: ⬇️ Checkout sources
         uses: actions/checkout@v3
-      - name: 🏗️ Project files
+      - name: 🏗️ Setup project files
         run: |
           mkdir build
           cd build
           cmake --log-level=WARNING -DORC_BUILD_EXAMPLES=0 -GXcode ..
-      - name: 🛠️ ORC
+      - name: 🛠️ Build ORC
         run: |
           xcodebuild -json -project ./build/orc.xcodeproj -scheme orc_orc -configuration Release -hideShellScriptEnvironment
-      - name: ✏️ Compress
+      - name: 🗜️ Compress binary
         run: |
-          tar -zcvf orc-${{ env.NEXT_TAG }}-macos.tgz build/Release/orc
-      - name: ✍️ Release
+          tar -zcvf ${{env.artifact_name}} build/Release/orc
+      - name: ✍️ Release archive
         uses: softprops/action-gh-release@v1
         with:
           generate_release_notes: true
           files:
-            orc-${{ env.NEXT_TAG }}-macos.tgz
+            ${{env.artifact_name}}


### PR DESCRIPTION
This adds a GitHub Action that will build and post a build of ORC for macOS to an associated tag.

# Tag Notes

Create an annotated tag via:
```shell
git tag -a v2.1.0 -m "xyz feature is released in this tag."
```

Pushing a specific tag:
```shell
git push origin v2.1.0
```

Update a tag to a new commit (in this case, commit `9096c13`):
```shell
git tag -f v2.1.0 9096c13
```

Once a tag has been updated locally, it must be forcibly re-pushed to GitHub:
```shell
git push origin --force v2.1.0
```

