### PR TITLE
Starting to add resource metrics on runs of the tool.

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -26,6 +26,7 @@ jobs:
       - name: 🗜️ Create archive
         run: |
           cd build/Release
+          xattr -d com.apple.quarantine orc
           tar -zcvf orc-${{github.ref_name}}-${{runner.os}}-${{runner.arch}}.tgz orc
       - name: ✍️ Post archive
         uses: softprops/action-gh-release@v1

--- a/_orc-config
+++ b/_orc-config
@@ -94,6 +94,13 @@ print_object_file_list = false
 
 parallel_processing = true
 
+# `resource_metrics`, when true, will cause ORC to emit various metrics regarding resource
+# (time, memory, etc.) consumption.
+#
+# The default value is `false`.
+
+resource_metrics = false
+
 # `symbol_ignore` is a list of symbol names ORC should ignore.
 
 # symbol_ignore = [

--- a/include/orc/dwarf_structs.hpp
+++ b/include/orc/dwarf_structs.hpp
@@ -356,16 +356,32 @@ bool sorted_has(const Container& c, const T& x) {
 /**************************************************************************************************/
 // Quick and dirty type to print an integer value as a padded, fixed-width hex value.
 // e.g., std::cout << hex_print(my_int) << '\n';
-struct hex_print {
-    explicit hex_print(std::size_t x) : _x{x} {}
-    std::size_t _x;
+template <class Integral>
+struct hex_print_t {
+    explicit hex_print_t(Integral x) : _x{x} {}
+    Integral _x;
 };
 
-inline std::ostream& operator<<(std::ostream& s, const hex_print& x) {
-    s << "0x";
-    s.width(8);
-    s.fill('0');
-    return s << std::hex << x._x << std::dec;
+template <class Integral>
+auto hex_print(Integral x) {
+    return hex_print_t<Integral>(x);
+}
+
+struct flag_saver {
+    explicit flag_saver(std::ios_base& s) : _s{s}, _f{_s.flags()} {}
+    ~flag_saver() { _s.setf(_f); }
+
+private:
+    std::ios_base& _s;
+    std::ios_base::fmtflags _f;
+};
+
+template <class Integral>
+inline std::ostream& operator<<(std::ostream& s, const hex_print_t<Integral>& x) {
+    constexpr auto width_k = sizeof(x._x) * 2 + 2; // +2 to the width for std::showbase
+    flag_saver fs(s);
+    return s << std::internal << std::showbase << std::hex << std::setw(width_k)
+             << std::setfill('0') << x._x;
 }
 
 /**************************************************************************************************/

--- a/include/orc/settings.hpp
+++ b/include/orc/settings.hpp
@@ -44,6 +44,7 @@ struct settings {
     bool _show_progress{false};
     bool _filter_redundant{true};
     std::string _relative_output_file;
+    bool _resource_metrics{false};
 };
 
 /**************************************************************************************************/

--- a/include/orc/settings.hpp
+++ b/include/orc/settings.hpp
@@ -16,8 +16,6 @@
 // application
 #include "orc/features.hpp"
 
-#define ORC_PRIVATE_FEATURE_UNIQUE_SYMBOL_DIES() (0)
-
 /**************************************************************************************************/
 
 struct settings {
@@ -55,11 +53,8 @@ struct globals {
     std::atomic_size_t _object_file_count{0};
     std::atomic_size_t _odrv_count{0};
     std::atomic_size_t _unique_symbol_count{0};
-#if ORC_FEATURE(UNIQUE_SYMBOL_DIES)
-    std::atomic_size_t _unique_symbol_die_count{0};
-#endif // ORC_FEATURE(UNIQUE_SYMBOL_DIES)
     std::atomic_size_t _die_processed_count{0};
-    std::atomic_size_t _die_analyzed_count{0};
+    std::atomic_size_t _die_skipped_count{0};
     std::ofstream _fp;
 
 private:

--- a/include/orc/str.hpp
+++ b/include/orc/str.hpp
@@ -20,4 +20,9 @@ std::vector<std::string> split(const std::string& src, const std::string& delimi
 
 std::string join(std::vector<std::string> src, const std::string& delimiter);
 
+// pretty-print the size with two decimal places of precision
+// e.g., "12.34 MiB" (binary), or "12.34 MB" (decimal).
+enum class format_mode { binary, decimal };
+std::string size_format(std::size_t x, format_mode mode = format_mode::binary);
+
 /**************************************************************************************************/

--- a/include/orc/str.hpp
+++ b/include/orc/str.hpp
@@ -23,6 +23,14 @@ std::string join(std::vector<std::string> src, const std::string& delimiter);
 // pretty-print the size with two decimal places of precision
 // e.g., "12.34 MiB" (binary), or "12.34 MB" (decimal).
 enum class format_mode { binary, decimal };
-std::string size_format(std::size_t x, format_mode mode = format_mode::binary);
+std::string format_size(std::size_t x, format_mode mode = format_mode::binary);
+
+// pretty-print the floating-point as a percentage with two decimal places of precision.
+// e.g.,  .123 -> "12.3%", or 1.23456 -> "123.46%"
+std::string format_pct(float x);
+
+inline std::string format_pct(float x, float total) {
+    return format_pct(x / total);
+}
 
 /**************************************************************************************************/

--- a/include/orc/string_pool.hpp
+++ b/include/orc/string_pool.hpp
@@ -102,6 +102,11 @@ private:
     const char* _data{nullptr};
 };
 
+constexpr int string_pool_count_k = 23;
+
+std::array<std::size_t, string_pool_count_k> string_pool_sizes();
+std::array<std::size_t, string_pool_count_k> string_pool_wasted();
+
 // pool_string is just a pointer with methods. It needs to be small as strings are a large part
 // of ORC's considerable memory usage. pool_string doesn't have a copy constructor or move semantics. 
 // Copying and low memory usage depend on pool_string being really a pointer, so double check that here,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -402,7 +402,7 @@ auto epilogue(bool exception) {
 
     if (settings::instance()._resource_metrics) {
         const auto pool_sizes = string_pool_sizes();
-        const auto total_pool_size = std::accumulate(pool_sizes.begin(), pool_sizes.end(), 0);
+        const auto total_pool_size = std::accumulate(pool_sizes.begin(), pool_sizes.end(), 0ull);
         const auto pool_wasted = string_pool_wasted();
         const auto total_pool_wasted = std::accumulate(pool_wasted.begin(), pool_wasted.end(), 0);
         const auto die_memory_footprint((g._die_processed_count - g._die_skipped_count) * sizeof(die));
@@ -414,12 +414,12 @@ auto epilogue(bool exception) {
             for (std::size_t i(0); i < string_pool_count_k; ++i) {
                 s << "    " << i << ": " << format_size(pool_sizes[i]) << " (" << pool_sizes[i] << ") / "
                   << format_size(pool_wasted[i]) << " (" << pool_wasted[i] << ") / "
-                  << std::fixed << format_pct(pool_wasted[i], pool_sizes[i]) << "%\n";
+                  << std::fixed << format_pct(pool_wasted[i], pool_sizes[i]) << "\n";
             }
 
             s << "    totals: " << format_size(total_pool_size) << " (" << total_pool_size << ") / "
               << format_size(total_pool_wasted) << " (" << total_pool_wasted << ") / "
-              << format_pct(total_pool_wasted, total_pool_size) << "%\n";
+              << format_pct(total_pool_wasted, total_pool_size) << "\n";
             s << "  die footprint: " << format_size(die_memory_footprint) << " (" << die_memory_footprint << ") \n";
         });
     }

--- a/src/orc.cpp
+++ b/src/orc.cpp
@@ -12,6 +12,7 @@
 #include <cxxabi.h>
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <list>
 #include <mutex>
 #include <set>
@@ -123,6 +124,9 @@ bool type_equivalent(const attribute& x, const attribute& y) {
 /**************************************************************************************************/
 
 void update_progress() {
+    // Since moving to a multithreaded solution, progress is horribly broken. We should probably
+    // remove this feature, as I'm not aware of anyone using it.
+#if 0
     if (!settings::instance()._show_progress) return;
 
     std::size_t done = globals::instance()._die_analyzed_count;
@@ -134,6 +138,7 @@ void update_progress() {
         s << globals::instance()._odrv_count << " violation(s) found";
         s << "          "; // 10 spaces of overprint to clear out any previous lingerers
     });
+#endif
 }
 
 /**************************************************************************************************/
@@ -153,7 +158,8 @@ auto with_global_die_collection(F&& f) {
 /**************************************************************************************************/
 
 auto& global_die_map() {
-    static decltype(auto) map_s = orc::make_leaky<tbb::concurrent_unordered_map<std::size_t, die*>>();
+    static decltype(auto) map_s =
+        orc::make_leaky<tbb::concurrent_unordered_map<std::size_t, die*>>();
     return map_s;
 }
 
@@ -184,10 +190,8 @@ void register_dies(dies die_vector) {
         return --collection.end();
     });
 
-    globals::instance()._die_processed_count += dies.size();
-
     for (auto& d : dies) {
-        if (d._skippable) continue;
+        assert(!d._skippable);
 #if 0
         if (settings::instance()._print_symbol_paths) {
             // This is all horribly broken, especially now that we're calling this from multiple threads.
@@ -227,7 +231,7 @@ void register_dies(dies die_vector) {
         d_in_map._next_die = &d;
     }
 
-    globals::instance()._die_analyzed_count += dies.size();
+    globals::instance()._die_skipped_count += skip_count;
 
     update_progress();
 }
@@ -388,8 +392,7 @@ std::string odrv_report::category() const {
 }
 
 /**************************************************************************************************/
-bool filter_report(const odrv_report& report)
-{
+bool filter_report(const odrv_report& report) {
     std::string odrv_category = report.category();
 
     // Decide if we should report or ignore.
@@ -411,8 +414,7 @@ bool filter_report(const odrv_report& report)
 
 /**************************************************************************************************/
 
-std::ostream& operator<<(std::ostream& s, const odrv_report& report) 
-{    
+std::ostream& operator<<(std::ostream& s, const odrv_report& report) {
     const std::string_view& symbol = report._symbol;
     std::string odrv_category = report.category();
 
@@ -468,18 +470,6 @@ die* enforce_odrv_for_die_list(die* base, std::vector<odrv_report>& results) {
 }
 
 /**************************************************************************************************/
-#if ORC_FEATURE(UNIQUE_SYMBOL_DIES)
-auto unique_symbol_die_count() {
-    std::size_t count{0};
-    for (const auto& entry : global_die_map()) {
-        for (const die* ptr = entry.second; ptr; ptr = ptr->_next_die) {
-            ++count;
-        }
-    }
-    return count;
-}
-#endif // ORC_FEATURE(UNIQUE_SYMBOL_DIES)
-/**************************************************************************************************/
 
 std::vector<odrv_report> orc_process(const std::vector<std::filesystem::path>& file_list) {
     // First stage: process all the DIEs
@@ -501,10 +491,6 @@ std::vector<odrv_report> orc_process(const std::vector<std::filesystem::path>& f
     }
 
     work().wait();
-
-#if ORC_FEATURE(UNIQUE_SYMBOL_DIES)
-    globals::instance()._unique_symbol_die_count = unique_symbol_die_count();
-#endif // ORC_FEATURE(UNIQUE_SYMBOL_DIES)
 
     // Second stage: review DIEs for ODRVs
     std::vector<odrv_report> result;

--- a/src/str.cpp
+++ b/src/str.cpp
@@ -50,7 +50,7 @@ std::string join(std::vector<std::string> src, const std::string& delimiter) {
 
 /**************************************************************************************************/
 
-std::string size_format(std::size_t x, format_mode mode) {
+std::string format_size(std::size_t x, format_mode mode) {
     double v(x);
     std::size_t exponent{0};
     const std::size_t factor{mode == format_mode::binary ? 1024ul : 1000ul};
@@ -74,6 +74,18 @@ std::string size_format(std::size_t x, format_mode mode) {
     const bool with_precision = std::modf(v, &dummy) != 0;
     std::stringstream result;
     result << std::fixed << std::setprecision(with_precision ? 2 : 0) << v << ' ' << label;
+    return result.str();
+}
+
+/**************************************************************************************************/
+
+std::string format_pct(float x) {
+    x *= 100.;
+
+    float dummy(0);
+    const bool with_precision = std::modf(x, &dummy) != 0;
+    std::stringstream result;
+    result << std::fixed << std::setprecision(with_precision ? 2 : 0) << x << '%';
     return result.str();
 }
 

--- a/src/str.cpp
+++ b/src/str.cpp
@@ -7,6 +7,10 @@
 // identity
 #include "orc/str.hpp"
 
+// stdc++
+#include <cmath>
+#include <sstream>
+
 /**************************************************************************************************/
 
 std::string rstrip(std::string s) {
@@ -42,6 +46,35 @@ std::string join(std::vector<std::string> src, const std::string& delimiter) {
     for (std::size_t i = 1; i < src.size(); ++i)
         result += delimiter + src[i];
     return result;
+}
+
+/**************************************************************************************************/
+
+std::string size_format(std::size_t x, format_mode mode) {
+    double v(x);
+    std::size_t exponent{0};
+    const std::size_t factor{mode == format_mode::binary ? 1024ul : 1000ul};
+
+    while (v >= factor && exponent < 4) {
+        v /= factor;
+        ++exponent;
+    }
+
+    const char* label = [&]{
+        switch (exponent) {
+            case 0: return "bytes";
+            case 1: return mode == format_mode::binary ? "KiB" : "KB";
+            case 2: return mode == format_mode::binary ? "MiB" : "MB";
+            case 3: return mode == format_mode::binary ? "GiB" : "GB";
+            default: return mode == format_mode::binary ? "TiB" : "TB";
+        }
+    }();
+
+    float dummy(0);
+    const bool with_precision = std::modf(v, &dummy) != 0;
+    std::stringstream result;
+    result << std::fixed << std::setprecision(with_precision ? 2 : 0) << v << ' ' << label;
+    return result.str();
 }
 
 /**************************************************************************************************/


### PR DESCRIPTION
We are looking to improve our understanding of how ORC utilizes the machine resources during processing, possibly in order to identify tradeoffs we can make in space v. time. This PR adds some initial memory footprint metrics to the end of the ORC run's output, along with a flag to enable it.

Here's an example output:

```
Resource metrics:
  String pool size / waste:
    0: 32 MiB (33554432) / 2.19 MiB (2292587) / 6.83%
    1: 32 MiB (33554432) / 2.21 MiB (2316317) / 6.90%
    2: 32 MiB (33554432) / 2.20 MiB (2310493) / 6.89%
    3: 32 MiB (33554432) / 2.31 MiB (2420043) / 7.21%
    4: 32 MiB (33554432) / 2.41 MiB (2527218) / 7.53%
    5: 32 MiB (33554432) / 2.13 MiB (2231512) / 6.65%
    6: 32 MiB (33554432) / 2.19 MiB (2292399) / 6.83%
    7: 32 MiB (33554432) / 2.16 MiB (2269894) / 6.76%
    8: 32 MiB (33554432) / 2.13 MiB (2237163) / 6.67%
    9: 32 MiB (33554432) / 2.26 MiB (2370840) / 7.07%
    10: 32 MiB (33554432) / 2.30 MiB (2411155) / 7.19%
    11: 32 MiB (33554432) / 2.32 MiB (2429004) / 7.24%
    12: 32 MiB (33554432) / 2.25 MiB (2355728) / 7.02%
    13: 32 MiB (33554432) / 2.42 MiB (2537523) / 7.56%
    14: 32 MiB (33554432) / 2.30 MiB (2408363) / 7.18%
    15: 32 MiB (33554432) / 2.30 MiB (2409418) / 7.18%
    16: 32 MiB (33554432) / 2.23 MiB (2337468) / 6.97%
    17: 32 MiB (33554432) / 2.43 MiB (2544395) / 7.58%
    18: 32 MiB (33554432) / 2.54 MiB (2664409) / 7.94%
    19: 32 MiB (33554432) / 2.15 MiB (2258360) / 6.73%
    20: 32 MiB (33554432) / 2.40 MiB (2514859) / 7.49%
    21: 32 MiB (33554432) / 2.35 MiB (2464329) / 7.34%
    22: 32 MiB (33554432) / 2.30 MiB (2411696) / 7.19%
    totals: 736 MiB (771751936) / 52.47 MiB (55015173) / 7.13%
  die footprint: 5.31 GiB (5702569584) 
```