### PR TITLE
Removing two dead features

### DIFF
--- a/_orc-config
+++ b/_orc-config
@@ -30,14 +30,6 @@ filter_redundant = true
 
 forward_to_linker = true
 
-# Print the symbol paths as they are processed by ORC. Setting this value to `true` will result in
-# copious output. Because this can produce such a flurry of information, it is tracked separately
-# from log_level.
-#
-# The default value is `false`.
-
-print_symbol_paths = false
-
 # `log_level` determines how loud ORC should be. The following values can be used, in increasing
 # order of verbosity. The logging level does not affect ODR violation reporting.
 #
@@ -49,12 +41,6 @@ print_symbol_paths = false
 # The default value is `'warning'`.
 
 log_level = 'warning'
-
-# Output a die-count-based progress update throughout the session.
-#
-# The default value is `false`.
-
-show_progress = false
 
 # At the command line, expect a list of object/a/dylib files instead of the typical linker
 # command-line arguments. (This mode is largely helpful for debugging/testing the tool itself.)

--- a/include/orc/settings.hpp
+++ b/include/orc/settings.hpp
@@ -31,7 +31,6 @@ struct settings {
     bool _graceful_exit{false};
     std::size_t _max_violation_count{0};
     bool _forward_to_linker{true};
-    bool _print_symbol_paths{false};
     log_level _log_level{log_level::silent};
     bool _standalone_mode{false};
     bool _print_object_file_list{false};
@@ -39,7 +38,6 @@ struct settings {
     std::vector<std::string> _violation_report;
     std::vector<std::string> _violation_ignore;
     bool _parallel_processing{true};
-    bool _show_progress{false};
     bool _filter_redundant{true};
     std::string _relative_output_file;
     bool _resource_metrics{false};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -121,10 +121,8 @@ void process_orc_config_file(const char* bin_path_string) {
             app_settings._graceful_exit = settings["graceful_exit"].value_or(false);
             app_settings._max_violation_count = settings["max_error_count"].value_or(0);
             app_settings._forward_to_linker = settings["forward_to_linker"].value_or(true);
-            app_settings._print_symbol_paths = settings["print_symbol_paths"].value_or(false);
             app_settings._standalone_mode = settings["standalone_mode"].value_or(false);
             app_settings._parallel_processing = settings["parallel_processing"].value_or(true);
-            app_settings._show_progress = settings["show_progress"].value_or(false);
             app_settings._filter_redundant = settings["filter_redundant"].value_or(true);
             app_settings._print_object_file_list = settings["print_object_file_list"].value_or(false);
             app_settings._relative_output_file = settings["relative_output_file"].value_or("");
@@ -378,15 +376,6 @@ cmdline_results process_command_line(int argc, char** argv) {
 
 auto epilogue(bool exception) {
     const auto& g = globals::instance();
-
-    // If we were showing progress this session, take all the stored up ODRVs and output them
-    if (settings::instance()._show_progress) {
-        assert(false); // this code is currently broken, and needs rework :\
-        // cout_safe([&](auto& s){
-        //     s << '\n';
-        //     s << odrv_sstream().str();
-        // });
-    }
 
     if (log_level_at_least(settings::log_level::warning)) {
         cout_safe([&](auto& s) {

--- a/src/orc.cpp
+++ b/src/orc.cpp
@@ -123,26 +123,6 @@ bool type_equivalent(const attribute& x, const attribute& y) {
 
 /**************************************************************************************************/
 
-void update_progress() {
-    // Since moving to a multithreaded solution, progress is horribly broken. We should probably
-    // remove this feature, as I'm not aware of anyone using it.
-#if 0
-    if (!settings::instance()._show_progress) return;
-
-    std::size_t done = globals::instance()._die_analyzed_count;
-    std::size_t total = globals::instance()._die_processed_count;
-    std::size_t percentage = static_cast<double>(done) / total * 100;
-
-    cout_safe([&](auto& s) {
-        s << '\r' << done << "/" << total << "  " << percentage << "%; ";
-        s << globals::instance()._odrv_count << " violation(s) found";
-        s << "          "; // 10 spaces of overprint to clear out any previous lingerers
-    });
-#endif
-}
-
-/**************************************************************************************************/
-
 auto& unsafe_global_die_collection() {
     static decltype(auto) collection_s = orc::make_leaky<std::list<dies>>();
     return collection_s;
@@ -192,24 +172,6 @@ void register_dies(dies die_vector) {
 
     for (auto& d : dies) {
         assert(!d._skippable);
-#if 0
-        if (settings::instance()._print_symbol_paths) {
-            // This is all horribly broken, especially now that we're calling this from multiple threads.
-            static pool_string last_object_file_s;
-
-            cout_safe([&](auto& s){
-                if (d._object_file != last_object_file_s) {
-                    last_object_file_s = d._object_file;
-                    s << '\n' << last_object_file_s << '\n';
-                }
-
-                s << (should_skip ? 'S' : 'R') << " - 0x";
-                s.width(8);
-                s.fill('0');
-                s << std::hex << d._debug_info_offset << std::dec << " " << d._path << '\n';
-            });
-        }
-#endif
 
         //
         // At this point we know we're going to register the die. Hereafter belongs
@@ -232,8 +194,6 @@ void register_dies(dies die_vector) {
     }
 
     globals::instance()._die_skipped_count += skip_count;
-
-    update_progress();
 }
 
 /**************************************************************************************************/


### PR DESCRIPTION
Removes two features that are no longer valuable - dumping symbol paths, and progress reporting. Both have been broken or compiled-out for some time. Fixes #61.