### PR TITLE
hotfixes

### DIFF
--- a/include/orc/parse_file.hpp
+++ b/include/orc/parse_file.hpp
@@ -31,17 +31,22 @@ struct freader {
     // `<=` here because sometimes we jump to one past the end of the buffer right before stopping.
     explicit operator bool() const { return static_cast<bool>(_buffer) && _p <= _l; }
 
-    std::size_t size() const { return _l - _p; }
+    std::size_t size() const {
+        assert(*this);
+        return _l - _p;
+    }
 
-    std::size_t tellg() const { return _p - _f; }
+    std::size_t tellg() const {
+        assert(*this);
+        return _p - _f;
+    }
 
     void seekg(std::istream::off_type offset) {
-        assert(*this);
         _p = _f + offset;
+        assert(*this);
     }
 
     void seekg(std::istream::off_type offset, std::ios::seekdir dir) {
-        assert(*this);
         switch (dir) {
             case std::ios::beg: {
                 _p = _f + offset;
@@ -59,25 +64,27 @@ struct freader {
                 assert(false);
             } break;
         }
+        assert(*this);
     }
 
     void read(char* p, std::size_t n) {
-        assert(*this);
         std::memcpy(p, _p, n);
         _p += n;
+        assert(*this);
     }
 
     char get() {
+        char result = *_p++;
         assert(*this);
-        return *_p++;
+        return result;
     }
 
     std::string_view read_c_string_view() {
-        assert(*this);
         auto f = _p;
         for (; *_p; ++_p) {
         }
         auto n = _p++ - f;
+        assert(*this);
         return std::string_view(f, n);
     }
 

--- a/src/dwarf_structs.cpp
+++ b/src/dwarf_structs.cpp
@@ -162,6 +162,14 @@ bool nonfatal_attribute(dw::at at) {
             dw::at::call_return_pc,
             dw::at::call_value,
             dw::at::containing_type,
+            // Item 10 of section 4.1 talks about the `const_value` attribute, saying the
+            // entry describes a constant parameter value that can take a number of different
+            // forms. Since ORC does not concern itself with parameter values, these should
+            // be safe to skip. (Unless it's talking about _template_ parameters? But I don't
+            // get that from the interpretation of the spec. I would expect the signature of
+            // the template to contain the constant value, and it not be something required
+            // of the target architecture, as is the case with `const_value`.)
+            dw::at::const_value,
             dw::at::decl_column,
             dw::at::decl_file,
             dw::at::decl_line,


### PR DESCRIPTION
A couple hotfixes.

## Description

- Additional assertions in `freader`
- Modified `die_hash` to be more accurate about what it includes when computing the die's hash.
- Typo in `evaluate_exprloc`
- "Better" `block` form handling. By "better" I mean we now throw an error if we see it, instead of treating it like an `exprloc`, which was _definitely_ not right. I am working off of the hunch that an attribute that has a `block` form will not contribute to an ODR. I have added an exception in case such an attribute is encountered, at which point we'll likely need an expensive fix.
- Added `const_value` to the list of nonfatal attributes.