### PR TITLE
Hotfixes

### DIFF
--- a/include/orc/dwarf_structs.hpp
+++ b/include/orc/dwarf_structs.hpp
@@ -81,7 +81,7 @@ struct attribute_value {
         return _string.hash();
     }
 
-    void reference(std::uint32_t offset) {
+    void reference(std::uint64_t offset) {
         _type |= type::reference;
         _uint = offset;
     }

--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -206,7 +206,7 @@ std::size_t die_hash(const die& d, const attribute_sequence& attributes) {
     // Ideally, tag would also not be part of this hash and all symbols, regardless of tag, would be
     // unique. However, that fails in at least one case:
     //
-    //     typedef struct {} S;
+    //     typedef struct S {} S;
     //
     // This results in both a `typedef` element and a `struct` element, with the same symbol path,
     // but which is not an ODRV.

--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -199,11 +199,7 @@ bool has_flag_attribute(const attribute_sequence& attributes, dw::at name) {
 std::size_t die_hash(const die& d, const attribute_sequence& attributes) {
     ZoneScoped;
     
-    // The `declaration` attribute used to be a part of this hash. Given that a declaration
-    // is not a definition, they cannot contribute to an ODRV, so were instead added to the
-    // `skip_die` logic, and removed from this hash.
-    
-    // Ideally, tag would also not be part of this hash and all symbols, regardless of tag, would be
+    // Ideally, tag would not be part of this hash and all symbols, regardless of tag, would be
     // unique. However, that fails in at least one case:
     //
     //     typedef struct S {} S;
@@ -228,6 +224,7 @@ std::size_t die_hash(const die& d, const attribute_sequence& attributes) {
     return orc::hash_combine(0,
                              static_cast<std::size_t>(d._arch),
                              static_cast<std::size_t>(tag),
+                             has_flag_attribute(attributes, dw::at::declaration),
                              d._path.hash());
     // clang-tidy on
 };

--- a/test/battery/class_struct/class.cpp
+++ b/test/battery/class_struct/class.cpp
@@ -1,0 +1,6 @@
+class object {
+    bool _x;
+    bool _y;
+};
+
+void f(const object& o) { }

--- a/test/battery/class_struct/odrv_test.toml
+++ b/test/battery/class_struct/odrv_test.toml
@@ -1,0 +1,8 @@
+[[source]]
+    path = "class.cpp"
+
+[[source]]
+    path = "struct.cpp"
+
+[[odrv]]
+    category = "structure:byte_size"

--- a/test/battery/class_struct/struct.cpp
+++ b/test/battery/class_struct/struct.cpp
@@ -1,0 +1,5 @@
+struct object {
+    bool _x;
+};
+
+void f(const object& o) { }

--- a/test/battery/typedef_struct/odrv_test.toml
+++ b/test/battery/typedef_struct/odrv_test.toml
@@ -1,0 +1,2 @@
+[[source]]
+    path = "src.cpp"

--- a/test/battery/typedef_struct/src.cpp
+++ b/test/battery/typedef_struct/src.cpp
@@ -1,0 +1,4 @@
+typedef struct S {int _i;} S;
+
+// Required so the compiler generates a symbol.
+int get(S s) { return s._i; }

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -172,8 +172,9 @@ auto object_file_path(const std::filesystem::path& battery_path, const compilati
 
 /**************************************************************************************************/
 
-std::string exec(const char* cmd) {
-    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd, "r"), pclose);
+std::string exec(std::string cmd) {
+    cmd += " 2>&1";
+    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"), pclose);
 
     if (!pipe) {
         throw std::runtime_error("popen() failed!");


### PR DESCRIPTION
## Description

Hotfixes:
- Fix for reading correct ref_addr in dwarf v2.
- Workaround for only reading partial decl_files list.
- Fix issue with tests not recognizing failed compilations.

## Related Issue

#67

## Motivation and Context

Workaround for issue.

## How Has This Been Tested?

Tests passing.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
