### PR TITLE
die post-processing subdivision

### DIFF
--- a/include/orc/dwarf_constants.hpp
+++ b/include/orc/dwarf_constants.hpp
@@ -86,7 +86,7 @@ enum class at : std::uint16_t {
     discr = 0x15,
     discr_value = 0x16,
     visibility = 0x17,
-    import = 0x18,
+    import_ = 0x18,
     string_length = 0x19,
     common_reference = 0x1a,
     comp_dir = 0x1b,

--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -761,10 +761,16 @@ pool_string dwarf::implementation::die_identifier(const die& d,
 
     // If the tag type doesn't give us a good name, then we scan various
     // attributes.
+    // clang-format off
     const dw::at string_attributes[] = {
-        dw::at::linkage_name,    dw::at::name,          dw::at::type, dw::at::import,
-        dw::at::abstract_origin, dw::at::specification,
+        dw::at::linkage_name,
+        dw::at::name,
+        dw::at::type,
+        dw::at::import_,
+        dw::at::abstract_origin,
+        dw::at::specification,
     };
+    // clang-format on
     for (const auto& at : string_attributes)
         if (attributes.has_string(at)) return attributes.string(at);
 

--- a/src/dwarf_constants.cpp
+++ b/src/dwarf_constants.cpp
@@ -36,7 +36,7 @@ const char* to_string(at attr) {
         case at::discr: return "discr";
         case at::discr_value: return "discr_value";
         case at::visibility: return "visibility";
-        case at::import: return "import";
+        case at::import_: return "import";
         case at::string_length: return "string_length";
         case at::common_reference: return "common_reference";
         case at::comp_dir: return "comp_dir";

--- a/src/dwarf_structs.cpp
+++ b/src/dwarf_structs.cpp
@@ -127,16 +127,6 @@ std::ostream& operator<<(std::ostream& s, const die& x) {
 
 /**************************************************************************************************/
 
-bool operator<(const die& x, const die& y) {
-    if (x._path.view() < y._path.view())
-        return true;
-    if (x._path.view() > y._path.view())
-        return false;
-    return object_file_ancestry(x._ofd_index) < object_file_ancestry(y._ofd_index);
-}
-
-/**************************************************************************************************/
-
 bool nonfatal_attribute(dw::at at) {
     static const auto attributes = [] {
         std::vector<dw::at> nonfatal_attributes = {

--- a/src/string_pool.cpp
+++ b/src/string_pool.cpp
@@ -192,7 +192,7 @@ pool_string empool(std::string_view src) {
 
     auto find_key = [&](std::size_t h) -> const char* {
         const auto found = keys.find(h);
-        return found == keys.end() ? nullptr ; found->second;
+        return found == keys.end() ? nullptr : found->second;
     };
 
     if (const char* c = find_key(h)) {

--- a/src/string_pool.cpp
+++ b/src/string_pool.cpp
@@ -176,6 +176,7 @@ std::size_t pool_string::get_hash(const char* d) {
 pool_string empool(std::string_view src) {
     ZoneScoped;
     ZoneColor(tracy::Color::ColorType::Green); // cache hit
+    ZoneText(src.data(), src.size());
 
     // A pool_string is empty iff _data = nullptr
     // So this creates an empty pool_string (as opposed to an empty string_view, where
@@ -213,6 +214,9 @@ pool_string empool(std::string_view src) {
     if (const char* c = find_key(h)) {
         pool_string ps(c);
         assert(ps.view() == src);
+
+        ZoneColor(tracy::Color::ColorType::Orange); // cache "half-hit"
+
         return ps;
     }
 

--- a/src/string_pool.cpp
+++ b/src/string_pool.cpp
@@ -29,6 +29,7 @@
 /*static*/ std::string_view pool_string::default_view("");
 
 #define ORC_PRIVATE_FEATURE_PROFILE_POOL_MEMORY() (ORC_PRIVATE_FEATURE_TRACY() && 0)
+#define ORC_PRIVATE_FEATURE_PROFILE_POOL_MUTEXES() (ORC_PRIVATE_FEATURE_TRACY() && 1)
 
 /**************************************************************************************************/
 
@@ -81,7 +82,7 @@ struct pool {
 #if ORC_FEATURE(PROFILE_POOL_MEMORY)
             assert(_id);
             tracy::Profiler::PlotData(_id, static_cast<int64_t>(_size));
-#endif // ORC_FEATURE(TRACY)
+#endif // ORC_FEATURE(PROFILE_POOL_MEMORY)
         }
 
         const std::size_t h = string_view_hash(incoming);
@@ -100,9 +101,38 @@ struct pool {
 
 /**************************************************************************************************/
 
+#if ORC_FEATURE(PROFILE_POOL_MUTEXES)
+    using string_pool_mutex = LockableBase(std::mutex);
+#else
+    using string_pool_mutex = std::mutex;
+#endif // ORC_FEATURE(PROFILE_POOL_MUTEXES)
+
+/**************************************************************************************************/
+
 auto& pool_mutex(std::size_t index) {
+    assert(index < string_pool_count_k);
+#if ORC_FEATURE(PROFILE_POOL_MUTEXES)
+    // I've been banging my head against this for a while, and this is the sadistic solution I've
+    // come up with. These are supposed to be a straightforward array of mutexes, of which one
+    // is picked when empooling a string, in order to reduce lock contention and blocking across
+    // the threads. The non-Tracy variant is what we want, but the Tracy variant requires a
+    // constructor parameter and is non-movable and non-copyable, so we have to construct them
+    // in place, which makes them very difficult to construct as a contiguous collection. So
+    // we allocate them dynamically and collect their pointers as a contiguous sequence, then
+    // index and dereference one of the pointers.
+    static string_pool_mutex** mutexes = []{
+        static std::vector<string_pool_mutex*> result;
+        for (std::size_t i(0); i < string_pool_count_k; ++i) {
+            static constexpr tracy::SourceLocationData srcloc { nullptr, "pool_mutex", TracyFile, TracyLine, 0 };
+            result.emplace_back(new string_pool_mutex(&srcloc));
+        }
+        return &result[0];
+    }();
+    return *mutexes[index];
+#else
     static std::mutex mutexes[string_pool_count_k];
     return mutexes[index];
+#endif // ORC_FEATURE(PROFILE_POOL_MUTEXES)
 }
 
 auto& pool(std::size_t index) {
@@ -115,7 +145,7 @@ auto& pool(std::size_t index) {
             TracyPlotConfig(pool_id, tracy::PlotFormatType::Memory, true, true, 0);
             result[i]._id = pool_id;
         }
-#endif // ORC_FEATURE(TRACY)
+#endif // ORC_FEATURE(PROFILE_POOL_MEMORY)
 
         return result;
     }();
@@ -176,15 +206,7 @@ pool_string empool(std::string_view src) {
     }
 
     const int index = h % string_pool_count_k;
-
-#if ORC_FEATURE(TRACY)
-    constexpr auto msg_sz_k = 32;
-    char msg[msg_sz_k] = {0};
-    std::snprintf(msg, msg_sz_k, "string pool %d", index);
-    ZoneTextL(msg);
-#endif // ORC_FEATURE(TRACY)
-
-    std::lock_guard<std::mutex> pool_guard(pool_mutex(index));
+    std::lock_guard<string_pool_mutex> pool_guard(pool_mutex(index));
 
     // Now that we have the lock, do the search again in case another thread empooled the string
     // while we were waiting for the lock.
@@ -211,7 +233,7 @@ std::array<std::size_t, string_pool_count_k> string_pool_sizes() {
     std::array<std::size_t, string_pool_count_k> result;
 
     for (std::size_t i(0); i < string_pool_count_k; ++i) {
-        std::lock_guard<std::mutex> pool_guard(pool_mutex(i));
+        std::lock_guard<string_pool_mutex> pool_guard(pool_mutex(i));
         result[i] = pool(i)._size;
     }
 
@@ -224,7 +246,7 @@ std::array<std::size_t, string_pool_count_k> string_pool_wasted() {
     std::array<std::size_t, string_pool_count_k> result;
 
     for (std::size_t i(0); i < string_pool_count_k; ++i) {
-        std::lock_guard<std::mutex> pool_guard(pool_mutex(i));
+        std::lock_guard<string_pool_mutex> pool_guard(pool_mutex(i));
         // Add the accumulated waste from previous ponds to the current pond's unused space.
         result[i] = pool(i)._wasted + pool(i)._n;
     }

--- a/src/tracy.cpp
+++ b/src/tracy.cpp
@@ -9,6 +9,7 @@
 
 // stdc++
 #include <cmath>
+#include <iostream>
 #include <sstream>
 
 //==================================================================================================
@@ -68,6 +69,11 @@ void initialize() {
         // The workaround is to connect the analyzer or preempt the application. In either
         // case, you're not losing profiling data.
         while (!profiler.HasShutdownFinished()) {
+            static bool do_once = []{
+                std::cout << "Waiting for Tracy...\n";
+                return true;
+            }();
+            (void)do_once;
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
         };
     });


### PR DESCRIPTION
This adds a couple new things to ORC:

- Subdividing die post-processing instead of one task per die entry. TL;DR: Instead of issuing a concurrent task for every die group, we subdivide all the groups into a set of chunks, one chunk per processor on the machine. This should reduce the scheduling overhead required for the post-processing phase of ORC, improving performance.
- Status output when ORC is blocked on Tracy on exit. This emits a little text blob when ORC is blocked waiting for data to get flushed to the Tracy analyzer.
- String pool mutex tracing. This allows us to see the contention in string pool mutexes so we can further optimize them.
- Renamed an enum which will conflict with c++ modules (`import`).