### PR TITLE
More comprehensive and deterministic reporting

### DIFF
--- a/_orc-config
+++ b/_orc-config
@@ -106,7 +106,8 @@ resource_metrics = false
 violation_report = [
     'class:byte_size',
     'member:data_member_location',
-    'member:type',
+    'member:alignment',
+#     'member:type',
     'structure:byte_size',
     'subprogram:virtuality',
     'subprogram:vtable_elem_location'

--- a/_orc-config
+++ b/_orc-config
@@ -47,7 +47,7 @@ log_level = 'warning'
 #
 # The default value is `false`.
 
-standalone_mode = false
+standalone_mode = true
 
 # If defined, ORC will log output to the specified file. (Normal stream output 
 # is unaffected by the `output_file`.) 
@@ -78,7 +78,7 @@ print_object_file_list = false
 #
 # The default value is `true`.
 
-parallel_processing = true
+parallel_processing = false
 
 # `resource_metrics`, when true, will cause ORC to emit various metrics regarding resource
 # (time, memory, etc.) consumption.

--- a/_orc-config
+++ b/_orc-config
@@ -78,7 +78,7 @@ print_object_file_list = false
 #
 # The default value is `true`.
 
-parallel_processing = false
+parallel_processing = true
 
 # `resource_metrics`, when true, will cause ORC to emit various metrics regarding resource
 # (time, memory, etc.) consumption.

--- a/_orc-config
+++ b/_orc-config
@@ -106,6 +106,7 @@ resource_metrics = false
 violation_report = [
     'class:byte_size',
     'member:data_member_location',
+    'member:type',
     'structure:byte_size',
     'subprogram:virtuality',
     'subprogram:vtable_elem_location'

--- a/_orc-config
+++ b/_orc-config
@@ -47,7 +47,7 @@ log_level = 'warning'
 #
 # The default value is `false`.
 
-standalone_mode = true
+standalone_mode = false
 
 # If defined, ORC will log output to the specified file. (Normal stream output 
 # is unaffected by the `output_file`.) 

--- a/include/orc/dwarf_structs.hpp
+++ b/include/orc/dwarf_structs.hpp
@@ -350,6 +350,7 @@ struct die {
     std::uint32_t _ofd_index{0}; // object file descriptor index
     std::size_t _cu_die_address{0}; // address of associated compilation unit die entry
     std::uint32_t _debug_info_offset{0}; // relative from top of __debug_info
+    std::optional<location> _location; // file_decl and file_line, if they exit for the die.
     dw::tag _tag{dw::tag::none};
     arch _arch{arch::unknown};
     bool _has_children{false};

--- a/include/orc/dwarf_structs.hpp
+++ b/include/orc/dwarf_structs.hpp
@@ -16,6 +16,7 @@
 
 // application
 #include "orc/dwarf_constants.hpp"
+#include "orc/hash.hpp"
 #include "orc/string_pool.hpp"
 
 /**************************************************************************************************/
@@ -251,7 +252,33 @@ private:
 
 std::ostream& operator<<(std::ostream& s, const attribute_sequence& x);
 
-std::optional<std::string> derive_definition_location(const attribute_sequence& x);
+/**************************************************************************************************/
+
+struct location {
+    pool_string file;
+    std::uint64_t loc{0};
+};
+
+inline bool operator==(const location& x, const location& y) {
+    return x.file == y.file && x.loc == y.loc;
+}
+inline bool operator!=(const location& x, const location& y) {
+    return !(x == y);
+}
+inline bool operator<(const location& x, const location& y) {
+    return x.file.hash() < y.file.hash() || (x.file == y.file && x.loc < y.loc);
+}
+
+template <>
+struct std::hash<location> {
+    std::size_t operator()(const location& x) const {
+        return orc::hash_combine(x.file.hash(), x.loc);
+    }
+};
+
+std::ostream& operator<<(std::ostream&, const location&);
+
+std::optional<location> derive_definition_location(const attribute_sequence& x);
 
 /**************************************************************************************************/
 

--- a/include/orc/dwarf_structs.hpp
+++ b/include/orc/dwarf_structs.hpp
@@ -10,6 +10,7 @@
 #include <array>
 #include <cassert>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -249,6 +250,8 @@ private:
 };
 
 std::ostream& operator<<(std::ostream& s, const attribute_sequence& x);
+
+std::optional<std::string> derive_definition_location(const attribute_sequence& x);
 
 /**************************************************************************************************/
 

--- a/include/orc/orc.hpp
+++ b/include/orc/orc.hpp
@@ -25,8 +25,10 @@ struct odrv_report {
     std::string category() const;
 
     struct conflict_details {
-        const die* _die{nullptr};
+        dw::tag _tag{dw::tag::none};
         attribute_sequence _attributes;
+        std::vector<std::string> _locations;
+        std::size_t _count{0}; // may be different than _locations.size()
     };
 
     const auto& conflict_map() const { return _conflict_map; }

--- a/include/orc/orc.hpp
+++ b/include/orc/orc.hpp
@@ -50,8 +50,8 @@ private:
 
 std::ostream& operator<<(std::ostream& s, const odrv_report& x);
 
-// Return `true` if an ODRV
-bool filter_report(const odrv_report& report);
+// Return `true` if the ODRV report is one we should emit
+bool emit_report(const odrv_report& report);
 
 /**************************************************************************************************/
 

--- a/include/orc/orc.hpp
+++ b/include/orc/orc.hpp
@@ -22,12 +22,19 @@
 struct odrv_report {
     odrv_report(std::string_view symbol, const die* list_head);
 
-    std::string category() const;
+    std::size_t category_count() const { return _conflicting_attributes.size(); }
+    std::string category(std::size_t n) const;
+    std::string reporting_categories() const;
+    std::string filtered_categories() const;
+
+    using symbol_instances = std::vector<std::string>;
+    using symbol_declaration = std::string;
+    using symbol_location_map = std::unordered_map<symbol_declaration, symbol_instances>;
 
     struct conflict_details {
         dw::tag _tag{dw::tag::none};
         attribute_sequence _attributes;
-        std::vector<std::string> _locations;
+        symbol_location_map _locations;
         std::size_t _count{0}; // may be different than _locations.size()
     };
 
@@ -38,7 +45,7 @@ struct odrv_report {
 private:
     const die* _list_head{nullptr};
     mutable std::map<std::size_t, conflict_details> _conflict_map;
-    dw::at _name{dw::at::none};
+    std::vector<dw::at> _conflicting_attributes;
 };
 
 std::ostream& operator<<(std::ostream& s, const odrv_report& x);
@@ -56,7 +63,15 @@ void orc_reset();
 const char* demangle(const char* x);
 
 /**************************************************************************************************/
+// TODO: (fosterbrereton) Find a better home for this somewhere?
+template <class C>
+void sort_unique(C& container) {
+    std::sort(container.begin(), container.end());
+    const auto new_end = std::unique(container.begin(), container.end());
+    container.erase(new_end, container.end());
+}
 
+/**************************************************************************************************/
 
 std::mutex& ostream_safe_mutex();
 

--- a/include/orc/orc.hpp
+++ b/include/orc/orc.hpp
@@ -27,8 +27,8 @@ struct odrv_report {
     std::string reporting_categories() const;
     std::string filtered_categories() const;
 
-    using symbol_instances = std::vector<std::string>;
-    using symbol_declaration = std::string;
+    using symbol_instances = std::vector<object_ancestry>;
+    using symbol_declaration = location;
     using symbol_location_map = std::unordered_map<symbol_declaration, symbol_instances>;
 
     struct conflict_details {

--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -1668,6 +1668,7 @@ void dwarf::implementation::process_all_dies() {
             die._ofd_index = _ofd_index;
             die._hash = die_hash(die, attributes);
             die._fatal_attribute_hash = fatal_attribute_hash(attributes);
+            die._location = derive_definition_location(attributes);
 
 #if ORC_FEATURE(PROFILE_DIE_DETAILS)
             auto path_view = die._path.view();

--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -22,6 +22,10 @@
 
 /**************************************************************************************************/
 
+#define ORC_PRIVATE_FEATURE_PROFILE_DIE_DETAILS() (ORC_PRIVATE_FEATURE_TRACY() && 0)
+
+/**************************************************************************************************/
+
 namespace {
 
 /**************************************************************************************************/
@@ -198,7 +202,9 @@ bool has_flag_attribute(const attribute_sequence& attributes, dw::at name) {
 /**************************************************************************************************/
 
 std::size_t die_hash(const die& d, const attribute_sequence& attributes) {
+#if ORC_FEATURE(PROFILE_DIE_DETAILS)
     ZoneScoped;
+#endif // ORC_FEATURE(PROFILE_DIE_DETAILS)
 
     // Ideally, tag would not be part of this hash and all symbols, regardless of tag, would be
     // unique. However, that fails in at least one case:
@@ -337,7 +343,9 @@ void line_header::read(freader& s, bool needs_byteswap) {
 /**************************************************************************************************/
 
 std::size_t fatal_attribute_hash(const attribute_sequence& attributes) {
+#if ORC_FEATURE(PROFILE_DIE_DETAILS)
     ZoneScoped;
+#endif // ORC_FEATURE(PROFILE_DIE_DETAILS)
 
     // We only hash the attributes that could contribute to an ODRV. We also sort that set of
     // attributes by name to make sure the hashing is consistent regardless of attribute order.
@@ -521,7 +529,9 @@ void dwarf::implementation::register_section(const std::string& name,
 /**************************************************************************************************/
 
 void dwarf::implementation::read_abbreviations() {
+#if ORC_FEATURE(PROFILE_DIE_DETAILS)
     ZoneScoped;
+#endif // ORC_FEATURE(PROFILE_DIE_DETAILS)
 
     auto section_begin = _debug_abbrev._offset;
     auto section_end = section_begin + _debug_abbrev._size;
@@ -538,7 +548,9 @@ void dwarf::implementation::read_abbreviations() {
 /**************************************************************************************************/
 
 void dwarf::implementation::read_lines(std::size_t header_offset) {
+#if ORC_FEATURE(PROFILE_DIE_DETAILS)
     ZoneScoped;
+#endif // ORC_FEATURE(PROFILE_DIE_DETAILS)
 
     temp_seek(_s, _debug_line._offset + header_offset, [&] {
         line_header header;
@@ -577,7 +589,9 @@ const abbrev& dwarf::implementation::find_abbreviation(std::uint32_t code) const
 #define ORC_PRIVATE_FEATURE_DEBUG_STR_CACHE() (ORC_PRIVATE_FEATURE_TRACY() && 0)
 
 pool_string dwarf::implementation::read_debug_str(std::size_t offset) {
+#if ORC_FEATURE(PROFILE_DIE_DETAILS)
     ZoneScoped;
+#endif // ORC_FEATURE(PROFILE_DIE_DETAILS)
 
 #if ORC_FEATURE(DEBUG_STR_CACHE)
     thread_local float hit_s(0);
@@ -635,7 +649,9 @@ void dwarf::implementation::path_identifier_pop() { _path.pop_back(); }
 
 std::string dwarf::implementation::qualified_symbol_name(
     const die& d, const attribute_sequence& attributes) const {
+#if ORC_FEATURE(PROFILE_DIE_DETAILS)
     ZoneScoped;
+#endif // ORC_FEATURE(PROFILE_DIE_DETAILS)
 
     // There are some attributes that contain the mangled name of the symbol.
     // This is a much better representation of the symbol than the derived path
@@ -1169,7 +1185,9 @@ attribute_value dwarf::implementation::evaluate_blockn(std::uint32_t size, dw::a
 
 attribute_value dwarf::implementation::process_form(const attribute& attr,
                                                     std::size_t cur_die_offset) {
+#if ORC_FEATURE(PROFILE_DIE_DETAILS)
     ZoneScoped;
+#endif // ORC_FEATURE(PROFILE_DIE_DETAILS)
 
     /*
         The values for `ref1`, `ref2`, `ref4`, and `ref8` are offsets from the first byte of
@@ -1339,7 +1357,9 @@ attribute_sequence dwarf::implementation::offset_to_attribute_sequence(std::size
 /**************************************************************************************************/
 
 pool_string dwarf::implementation::resolve_type(attribute type) {
+#if ORC_FEATURE(PROFILE_DIE_DETAILS)
     ZoneScoped;
+#endif // ORC_FEATURE(PROFILE_DIE_DETAILS)
 
     std::size_t reference = type.reference();
     auto found = _type_cache.find(reference);
@@ -1377,7 +1397,9 @@ pool_string dwarf::implementation::resolve_type(attribute type) {
 /**************************************************************************************************/
 
 die_pair dwarf::implementation::abbreviation_to_die(std::size_t die_address, process_mode mode) {
+#if ORC_FEATURE(PROFILE_DIE_DETAILS)
     ZoneScoped;
+#endif // ORC_FEATURE(PROFILE_DIE_DETAILS)
 
     die die;
     attribute_sequence attributes;
@@ -1442,14 +1464,18 @@ bool dwarf::implementation::register_sections_done() {
 /**************************************************************************************************/
 
 bool dwarf::implementation::skip_die(die& d, const attribute_sequence& attributes) {
+#if ORC_FEATURE(PROFILE_DIE_DETAILS)
     ZoneScoped;
     ZoneColor(tracy::Color::ColorType::Red);
+#endif // ORC_FEATURE(PROFILE_DIE_DETAILS)
 
     // These are a handful of "filters" we use to elide false positives.
 
     // These are the tags we don't deal with (yet, if ever.)
     if (skip_tagged_die(d)) {
+#if ORC_FEATURE(PROFILE_DIE_DETAILS)
         ZoneTextL("skipping: tagged die");
+#endif // ORC_FEATURE(PROFILE_DIE_DETAILS)
         return true;
     }
 
@@ -1457,40 +1483,52 @@ bool dwarf::implementation::skip_die(die& d, const attribute_sequence& attribute
     // flag means the function is invisible outside its compilation unit. As
     // such, it cannot contribute to an ODRV.
     if (d._tag == dw::tag::subprogram && !has_flag_attribute(attributes, dw::at::external)) {
+#if ORC_FEATURE(PROFILE_DIE_DETAILS)
         ZoneTextL("skipping: non-external subprogram");
+#endif // ORC_FEATURE(PROFILE_DIE_DETAILS)
         return true;
     }
 
     // Empty path means the die (or an ancestor) is anonymous/unnamed. No need to register
     // them.
     if (d._path.empty()) {
+#if ORC_FEATURE(PROFILE_DIE_DETAILS)
         ZoneTextL("skipping: empty path");
+#endif // ORC_FEATURE(PROFILE_DIE_DETAILS)
         return true;
     }
 
     // Symbols with __ in them are reserved, so are not user-defined. No need to register
     // them.
     if (d._path.view().find("::__") != std::string::npos) {
+#if ORC_FEATURE(PROFILE_DIE_DETAILS)
         ZoneTextL("skipping: non-user-defined (reserved) symbol");
+#endif // ORC_FEATURE(PROFILE_DIE_DETAILS)
         return true;
     }
 
     // lambdas are ephemeral and can't cause (hopefully) an ODRV
     if (d._path.view().find("lambda") != std::string::npos) {
+#if ORC_FEATURE(PROFILE_DIE_DETAILS)
         ZoneTextL("skipping: lambda");
+#endif // ORC_FEATURE(PROFILE_DIE_DETAILS)
         return true;
     }
 
     // we don't handle any die that's ObjC-based.
     if (attributes.has(dw::at::apple_runtime_class)) {
+#if ORC_FEATURE(PROFILE_DIE_DETAILS)
         ZoneTextL("skipping: apple runtime class");
+#endif // ORC_FEATURE(PROFILE_DIE_DETAILS)
         return true;
     }
 
     // If the symbol is listed in the symbol_ignore list, we're done here.
     std::string_view symbol = d._path.view();
     if (symbol.size() > 7 && sorted_has(settings::instance()._symbol_ignore, symbol.substr(7))) {
+#if ORC_FEATURE(PROFILE_DIE_DETAILS)
         ZoneTextL("skipping: on symbol_ignore list");
+#endif // ORC_FEATURE(PROFILE_DIE_DETAILS)
         return true;
     }
 
@@ -1508,14 +1546,18 @@ bool dwarf::implementation::skip_die(die& d, const attribute_sequence& attribute
         });
 
         if (empty) {
+#if ORC_FEATURE(PROFILE_DIE_DETAILS)
             ZoneTextL("skipping: self-referential type");
+#endif // ORC_FEATURE(PROFILE_DIE_DETAILS)
             return true;
         }
     }
 
     // This makes the kept dies visually identifiable in the Tracy analyzer.
+#if ORC_FEATURE(PROFILE_DIE_DETAILS)
     TracyMessageL("odr_used");
     ZoneColor(tracy::Color::ColorType::Green);
+#endif // ORC_FEATURE(PROFILE_DIE_DETAILS)
     return false;
 }
 
@@ -1562,7 +1604,9 @@ void dwarf::implementation::process_all_dies() {
 
         // process dies one at a time, recording things like addresses along the way.
         while (true) {
+#if ORC_FEATURE(PROFILE_DIE_DETAILS)
             ZoneScopedN("process_one_die"); // name matters for stats tracking
+#endif // ORC_FEATURE(PROFILE_DIE_DETAILS)
 
             const std::size_t die_absolute_offset = _s.tellg();
             die die;
@@ -1580,10 +1624,10 @@ void dwarf::implementation::process_all_dies() {
 
             die._cu_die_address = _cu_die_address;
 
-#if ORC_FEATURE(TRACY)
+#if ORC_FEATURE(PROFILE_DIE_DETAILS)
             const char* tag_str = to_string(die._tag);
             ZoneNameL(tag_str);
-#endif // ORC_FEATURE(TRACY)
+#endif // ORC_FEATURE(PROFILE_DIE_DETAILS)
 
             // Useful for looking up symbols in dwarfdump output.
 #if ORC_FEATURE(DEBUG) && 0
@@ -1625,7 +1669,7 @@ void dwarf::implementation::process_all_dies() {
             die._hash = die_hash(die, attributes);
             die._fatal_attribute_hash = fatal_attribute_hash(attributes);
 
-#if ORC_FEATURE(TRACY)
+#if ORC_FEATURE(PROFILE_DIE_DETAILS)
             auto path_view = die._path.view();
             if (!path_view.empty()) {
                 ZoneText(path_view.data(), path_view.length());
@@ -1638,7 +1682,7 @@ void dwarf::implementation::process_all_dies() {
             ZoneTextL(msg);
             std::snprintf(msg, msg_sz_k, "%zu attribute(s)", attributes.size());
             ZoneTextL(msg);
-#endif // ORC_FEATURE(TRACY)
+#endif // ORC_FEATURE(PROFILE_DIE_DETAILS)
 
             dies.emplace_back(std::move(die));
         }
@@ -1701,7 +1745,9 @@ void dwarf::implementation::post_process_die_attributes(attribute_sequence& attr
 
 die_pair dwarf::implementation::fetch_one_die(std::size_t debug_info_offset,
                                               std::size_t cu_die_address) {
+#if ORC_FEATURE(PROFILE_DIE_DETAILS)
     ZoneScoped;
+#endif // ORC_FEATURE(PROFILE_DIE_DETAILS)
 
     if (!_ready && !register_sections_done()) throw std::runtime_error("dwarf setup failed");
 

--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -1220,7 +1220,8 @@ attribute_value dwarf::implementation::process_form(const attribute& attr,
 
     const auto handle_passover = [&]() {
         if (fatal_attribute(attr._name)) {
-            throw std::runtime_error(std::string("Passing over an essential attribute (") + to_string(attr._name) + ")");
+            throw std::runtime_error(std::string("Passing over an essential attribute (") +
+                                     to_string(attr._name) + ")");
         }
         result.passover();
         auto size = form_length(attr._form, _s);
@@ -1563,9 +1564,11 @@ bool dwarf::implementation::skip_die(die& d, const attribute_sequence& attribute
 
 /**************************************************************************************************/
 
-void dwarf::implementation::report_die_processing_failure(std::size_t die_absolute_offset, std::string&& error) {
+void dwarf::implementation::report_die_processing_failure(std::size_t die_absolute_offset,
+                                                          std::string&& error) {
     if (log_level_at_least(settings::log_level::warning)) {
-        const auto debug_info_offset = static_cast<std::uint32_t>(die_absolute_offset - _debug_info._offset);
+        const auto debug_info_offset =
+            static_cast<std::uint32_t>(die_absolute_offset - _debug_info._offset);
 
         cerr_safe([&](auto& s) {
             s << "warning: failed to process die\n"
@@ -1613,7 +1616,8 @@ void dwarf::implementation::process_all_dies() {
             attribute_sequence attributes;
 
             try {
-                std::tie(die, attributes) = abbreviation_to_die(die_absolute_offset, process_mode::complete);
+                std::tie(die, attributes) =
+                    abbreviation_to_die(die_absolute_offset, process_mode::complete);
             } catch (const std::exception& error) {
                 // `report_die_processing_failure` will rethrow
                 report_die_processing_failure(die_absolute_offset, error.what());

--- a/src/dwarf_structs.cpp
+++ b/src/dwarf_structs.cpp
@@ -99,15 +99,21 @@ std::ostream& operator<<(std::ostream& s, const attribute& x) {
 
 /**************************************************************************************************/
 
-std::optional<std::string> derive_definition_location(const attribute_sequence& x) {
+std::ostream& operator<<(std::ostream& s, const location& x) {
+    return s << "    " << x.file << ": " << x.loc;
+}
+
+std::optional<location> derive_definition_location(const attribute_sequence& x) {
     if (!x.has_string(dw::at::decl_file)) {
         return std::nullopt;
     }
 
-    std::string result = x.string(dw::at::decl_file).allocate_string();
+    location result;
+
+    result.file = x.string(dw::at::decl_file);
 
     if (x.has_uint(dw::at::decl_line)) {
-        result += ":" + std::to_string(x.uint(dw::at::decl_line));
+        result.loc = x.uint(dw::at::decl_line);
     }
 
     return result;

--- a/src/dwarf_structs.cpp
+++ b/src/dwarf_structs.cpp
@@ -11,8 +11,8 @@
 #include <filesystem>
 
 // application
-#include "orc/parse_file.hpp"
 #include "orc/object_file_registry.hpp"
+#include "orc/parse_file.hpp"
 
 /**************************************************************************************************/
 
@@ -143,7 +143,7 @@ std::ostream& operator<<(std::ostream& s, const object_ancestry& x) {
             s << " -> ";
         }
 
-        s << ancestor.allocate_path().filename().string() ;
+        s << ancestor.allocate_path().filename().string();
     }
     return s;
 }

--- a/src/dwarf_structs.cpp
+++ b/src/dwarf_structs.cpp
@@ -116,10 +116,7 @@ std::optional<std::string> derive_definition_location(const attribute_sequence& 
 /**************************************************************************************************/
 
 std::ostream& operator<<(std::ostream& s, const attribute_sequence& x) {
-    // if (const auto location = derive_definition_location(x)) {
-    //     s << "        definition location: " << *location << '\n';
-    // }
-
+    // file and line are covered by the `odrv_report`, so should be skipped here.
     for (const auto& attr : x) {
         if (attr._name == dw::at::decl_file) continue;
         if (attr._name == dw::at::decl_line) continue;
@@ -145,19 +142,6 @@ std::ostream& operator<<(std::ostream& s, const object_ancestry& x) {
     return s;
 }
 
-/**************************************************************************************************/
-#if 0
-std::ostream& operator<<(std::ostream& s, const die& x) {
-    s << "    within: " << object_file_ancestry(x._ofd_index) << ":\n";
-
-    // Save for debugging so we can map what we find with dwarfdump output
-#if 0
-    s << "        debug_info offset: " << hex_print(x._debug_info_offset) << '\n';
-#endif
-
-    return s;
-}
-#endif
 /**************************************************************************************************/
 
 bool nonfatal_attribute(dw::at at) {

--- a/src/dwarf_structs.cpp
+++ b/src/dwarf_structs.cpp
@@ -94,21 +94,31 @@ std::ostream& operator<<(std::ostream& s, const attribute_value& x) {
 /**************************************************************************************************/
 
 std::ostream& operator<<(std::ostream& s, const attribute& x) {
-    return s << "        " << to_string(x._name) << ": " << x._value;
+    return s << "    " << to_string(x._name) << ": " << x._value;
+}
+
+/**************************************************************************************************/
+
+std::optional<std::string> derive_definition_location(const attribute_sequence& x) {
+    if (!x.has_string(dw::at::decl_file)) {
+        return std::nullopt;
+    }
+
+    std::string result = x.string(dw::at::decl_file).allocate_string();
+
+    if (x.has_uint(dw::at::decl_line)) {
+        result += ":" + std::to_string(x.uint(dw::at::decl_line));
+    }
+
+    return result;
 }
 
 /**************************************************************************************************/
 
 std::ostream& operator<<(std::ostream& s, const attribute_sequence& x) {
-    if (x.has_string(dw::at::decl_file)) {
-        s << "        definition location: " << x.string(dw::at::decl_file);
-
-        if (x.has_uint(dw::at::decl_line)) {
-            s << ":" + std::to_string(x.uint(dw::at::decl_line));
-        }
-
-        s << '\n';
-    }
+    // if (const auto location = derive_definition_location(x)) {
+    //     s << "        definition location: " << *location << '\n';
+    // }
 
     for (const auto& attr : x) {
         if (attr._name == dw::at::decl_file) continue;
@@ -136,7 +146,7 @@ std::ostream& operator<<(std::ostream& s, const object_ancestry& x) {
 }
 
 /**************************************************************************************************/
-
+#if 0
 std::ostream& operator<<(std::ostream& s, const die& x) {
     s << "    within: " << object_file_ancestry(x._ofd_index) << ":\n";
 
@@ -147,7 +157,7 @@ std::ostream& operator<<(std::ostream& s, const die& x) {
 
     return s;
 }
-
+#endif
 /**************************************************************************************************/
 
 bool nonfatal_attribute(dw::at at) {

--- a/src/macho.cpp
+++ b/src/macho.cpp
@@ -239,8 +239,7 @@ dwarf dwarf_from_macho(std::uint32_t ofd_index, register_dies_callback&& callbac
 
     s.seekg(entry._details._offset);
 
-    return dwarf_from_macho(ofd_index, std::move(s), copy(entry._details),
-                            std::move(callback));
+    return dwarf_from_macho(ofd_index, std::move(s), copy(entry._details), std::move(callback));
 }
 
 /**************************************************************************************************/

--- a/src/macho.cpp
+++ b/src/macho.cpp
@@ -16,6 +16,7 @@
 #include "orc/object_file_registry.hpp"
 #include "orc/settings.hpp"
 #include "orc/str.hpp"
+#include "orc/tracy.hpp"
 
 /**************************************************************************************************/
 
@@ -218,6 +219,8 @@ void read_macho(object_ancestry&& ancestry,
     callbacks._do_work([_ancestry = std::move(ancestry), _s = std::move(s),
                         _details = std::move(details),
                         _callback = std::move(callbacks._register_die)]() mutable {
+        ZoneScoped;
+
         ++globals::instance()._object_file_count;
 
         std::uint32_t ofd_index = static_cast<std::uint32_t>(object_file_register(std::move(_ancestry), copy(_details)));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -522,7 +522,7 @@ int main(int argc, char** argv) try {
     const auto max_odrv_count = settings::instance()._max_violation_count;
 
     for (const auto& report : reports) {
-        if (!filter_report(report)) {
+        if (!emit_report(report)) {
             filtered_categories.push_back(report.filtered_categories());
             continue;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,8 +11,8 @@
 #include <filesystem>
 #include <fstream>
 #include <list>
-#include <numeric>
 #include <mutex>
+#include <numeric>
 #include <set>
 #include <thread>
 #include <unordered_map>
@@ -70,8 +70,7 @@ std::string exec(const char* cmd) {
     return result;
 }
 
-void open_output_file(const std::string& a, const std::string& b)
-{
+void open_output_file(const std::string& a, const std::string& b) {
     std::filesystem::path path(b);
     if (!a.empty()) {
         path = a + '.' + b;
@@ -82,7 +81,6 @@ void open_output_file(const std::string& a, const std::string& b)
 /**************************************************************************************************/
 
 void process_orc_config_file(const char* bin_path_string) {
-
     std::filesystem::path pwd(std::filesystem::current_path());
     std::filesystem::path bin_path(pwd / bin_path_string);
     std::filesystem::path config_path;
@@ -145,9 +143,8 @@ void process_orc_config_file(const char* bin_path_string) {
                 } else {
                     // not a known value. Switch to verbose!
                     app_settings._log_level = settings::log_level::verbose;
-                    cout_safe([&](auto& s){
-                        s << "warning: Unknown log level (using verbose)\n";
-                    });
+                    cout_safe(
+                        [&](auto& s) { s << "warning: Unknown log level (using verbose)\n"; });
                 }
             }
 
@@ -171,7 +168,7 @@ void process_orc_config_file(const char* bin_path_string) {
             if (!app_settings._violation_report.empty() &&
                 !app_settings._violation_ignore.empty()) {
                 if (log_level_at_least(settings::log_level::warning)) {
-                    cout_safe([&](auto& s){
+                    cout_safe([&](auto& s) {
                         s << "warning: Both `violation_report` and `violation_ignore` lists found\n";
                         s << "warning: `violation_report` will be ignored in favor of `violation_ignore`\n";
                     });
@@ -180,20 +177,16 @@ void process_orc_config_file(const char* bin_path_string) {
 
 
             if (log_level_at_least(settings::log_level::info)) {
-                cout_safe([&](auto& s){
-                   s << "info: ORC config file: " << config_path.string() << "\n";
+                cout_safe([&](auto& s) {
+                    s << "info: ORC config file: " << config_path.string() << "\n";
                 });
             }
         } catch (const toml::parse_error& err) {
-            cerr_safe([&](auto& s) {
-                s << "Parsing failed:\n" << err << "\n";
-            });
+            cerr_safe([&](auto& s) { s << "Parsing failed:\n" << err << "\n"; });
             throw std::runtime_error("configuration parsing error");
         }
     } else {
-        cerr_safe([&](auto& s){
-           s << "ORC config file: not found\n";
-        });
+        cerr_safe([&](auto& s) { s << "ORC config file: not found\n"; });
     }
 }
 
@@ -247,11 +240,10 @@ struct cmdline_results {
 /**************************************************************************************************/
 
 cmdline_results process_command_line(int argc, char** argv) {
-
     cmdline_results result;
 
     if (log_level_at_least(settings::log_level::verbose)) {
-        cout_safe([&](auto& s){
+        cout_safe([&](auto& s) {
             s << "verbose: arguments:\n";
             for (std::size_t i{0}; i < argc; ++i) {
                 s << "  " << argv[i] << '\n';
@@ -274,7 +266,7 @@ cmdline_results process_command_line(int argc, char** argv) {
             std::string_view arg = argv[i];
             if (arg == "-o" || arg == "--output") {
                 std::string filename(argv[++i]);
-                
+
                 if (!settings::instance()._relative_output_file.empty()) {
                     open_output_file(filename, settings::instance()._relative_output_file);
                 }
@@ -286,16 +278,13 @@ cmdline_results process_command_line(int argc, char** argv) {
                     if (filename.ends_with(".a")) {
                         result._libtool_mode = true;
                         if (log_level_at_least(settings::log_level::verbose)) {
-                            cout_safe([&](auto& s){ 
-                                s << "verbose: mode: libtool (by filename)\n";
-                            });
+                            cout_safe(
+                                [&](auto& s) { s << "verbose: mode: libtool (by filename)\n"; });
                         }
                     } else {
                         result._ld_mode = true;
                         if (log_level_at_least(settings::log_level::verbose)) {
-                            cout_safe([&](auto& s){
-                                s << "verbose: mode: ld (by filename)\n";
-                            });
+                            cout_safe([&](auto& s) { s << "verbose: mode: ld (by filename)\n"; });
                         }
                     }
                 }
@@ -309,17 +298,13 @@ cmdline_results process_command_line(int argc, char** argv) {
                 result._libtool_mode = true;
                 assert(!result._ld_mode);
                 if (log_level_at_least(settings::log_level::verbose)) {
-                    cout_safe([&](auto& s){
-                        s << "verbose: mode: libtool (static)\n";
-                    });
+                    cout_safe([&](auto& s) { s << "verbose: mode: libtool (static)\n"; });
                 }
             } else if (arg == "-target") {
                 result._ld_mode = true;
                 assert(!result._libtool_mode);
                 if (log_level_at_least(settings::log_level::verbose)) {
-                    cout_safe([&](auto& s){
-                        s << "verbose: mode: ld (target)\n";
-                    });
+                    cout_safe([&](auto& s) { s << "verbose: mode: ld (target)\n"; });
                 }
             } else if (arg == "-lc++") {
                 // ignore the C++ standard library
@@ -393,22 +378,24 @@ auto epilogue(bool exception) {
         const auto total_pool_size = std::accumulate(pool_sizes.begin(), pool_sizes.end(), 0ull);
         const auto pool_wasted = string_pool_wasted();
         const auto total_pool_wasted = std::accumulate(pool_wasted.begin(), pool_wasted.end(), 0);
-        const auto die_memory_footprint((g._die_processed_count - g._die_skipped_count) * sizeof(die));
+        const auto die_memory_footprint((g._die_processed_count - g._die_skipped_count) *
+                                        sizeof(die));
 
         cout_safe([&](auto& s) {
             s << "Resource metrics:\n"
               << "  String pool size / waste:\n";
 
             for (std::size_t i(0); i < string_pool_count_k; ++i) {
-                s << "    " << i << ": " << format_size(pool_sizes[i]) << " (" << pool_sizes[i] << ") / "
-                  << format_size(pool_wasted[i]) << " (" << pool_wasted[i] << ") / "
+                s << "    " << i << ": " << format_size(pool_sizes[i]) << " (" << pool_sizes[i]
+                  << ") / " << format_size(pool_wasted[i]) << " (" << pool_wasted[i] << ") / "
                   << std::fixed << format_pct(pool_wasted[i], pool_sizes[i]) << "\n";
             }
 
             s << "    totals: " << format_size(total_pool_size) << " (" << total_pool_size << ") / "
               << format_size(total_pool_wasted) << " (" << total_pool_wasted << ") / "
               << format_pct(total_pool_wasted, total_pool_size) << "\n";
-            s << "  die footprint: " << format_size(die_memory_footprint) << " (" << die_memory_footprint << ") \n";
+            s << "  die footprint: " << format_size(die_memory_footprint) << " ("
+              << die_memory_footprint << ") \n";
         });
     }
 
@@ -454,7 +441,7 @@ void maybe_forward_to_linker(int argc, char** argv, const cmdline_results& cmdli
         executable_path /= "libtool";
     } else {
         if (log_level_at_least(settings::log_level::warning)) {
-            cout_safe([&](auto& s){
+            cout_safe([&](auto& s) {
                 s << "warning: libtool/ld mode could not be derived; forwarding to linker disabled\n";
             });
         }
@@ -465,9 +452,8 @@ void maybe_forward_to_linker(int argc, char** argv, const cmdline_results& cmdli
     if (!exists(executable_path)) {
         throw std::runtime_error("Could not forward to linker: " + executable_path.string());
     } else if (log_level_at_least(settings::log_level::verbose)) {
-        cout_safe([&](auto& s){
-            s << "verbose: forwarding to " + executable_path.string() + "\n";
-        });
+        cout_safe(
+            [&](auto& s) { s << "verbose: forwarding to " + executable_path.string() + "\n"; });
     }
 
     std::string arguments = executable_path.string();
@@ -479,9 +465,7 @@ void maybe_forward_to_linker(int argc, char** argv, const cmdline_results& cmdli
     // REVISIT: (fbrereto) We may need to capture/forward stderr here as well.
     // Also, if the execution of the linker ended in a failure, we need to bubble
     // that up immediately, and preempt ORC processing.
-    cout_safe([&](auto& s){
-        s << exec(arguments.c_str());
-    });
+    cout_safe([&](auto& s) { s << exec(arguments.c_str()); });
 }
 
 /**************************************************************************************************/
@@ -502,9 +486,7 @@ int main(int argc, char** argv) try {
 
     if (settings::instance()._print_object_file_list) {
         for (const auto& input_path : file_list) {
-            cout_safe([&](auto& s){
-                s << input_path.string() << '\n';
-            });
+            cout_safe([&](auto& s) { s << input_path.string() << '\n'; });
         }
 
         return EXIT_SUCCESS;
@@ -534,9 +516,7 @@ int main(int argc, char** argv) try {
 
         if (max_odrv_count > 0 && globals::instance()._odrv_count >= max_odrv_count) {
             if (log_level_at_least(settings::log_level::warning)) {
-                cout_safe([&](auto& s){
-                    s << "warning: ODRV limit reached\n";
-                });
+                cout_safe([&](auto& s) { s << "warning: ODRV limit reached\n"; });
             }
             break;
         }
@@ -545,16 +525,17 @@ int main(int argc, char** argv) try {
     assert(globals::instance()._odrv_count == violations.size());
 
     for (const auto& report : violations) {
-        cout_safe([&](auto& s){
-            s << report; // important to NOT add the '\n' because lots of reports are empty and it creates a lot of blank lines
+        cout_safe([&](auto& s) {
+            s << report; // important to NOT add the '\n' because lots of reports are empty and it
+                         // creates a lot of blank lines
         });
     }
 
     if (!filtered_categories.empty()) {
         const auto count = filtered_categories.size();
         sort_unique(filtered_categories);
-        cout_safe([&](auto& s){
-            s << "Filtered out " << count << " ODRVs in the following categories:\n";
+        cout_safe([&](auto& s) {
+            s << "Filtered out " << count << " reports in the following categories:\n";
             for (const auto& category : filtered_categories) {
                 s << "    " << category << '\n';
             }
@@ -564,14 +545,10 @@ int main(int argc, char** argv) try {
 
     return epilogue(false);
 } catch (const std::exception& error) {
-    cerr_safe([&](auto& s) {
-        s << "Fatal error: " << error.what() << '\n';
-    });
+    cerr_safe([&](auto& s) { s << "Fatal error: " << error.what() << '\n'; });
     return epilogue(true);
 } catch (...) {
-    cerr_safe([&](auto& s) {
-        s << "Fatal error: unknown\n";
-    });
+    cerr_safe([&](auto& s) { s << "Fatal error: unknown\n"; });
     return epilogue(false);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -520,16 +520,16 @@ int main(int argc, char** argv) try {
     std::vector<odrv_report> violations;
 
     for (const auto& report : reports) {
-        if (filter_report(report)) {
-            violations.push_back(report);
+        if (!filter_report(report)) continue;
 
-            // Administrivia
-            ++globals::instance()._odrv_count;
+        violations.push_back(report);
 
-            if (settings::instance()._max_violation_count > 0 &&
-                globals::instance()._odrv_count >= settings::instance()._max_violation_count) {
-                throw std::runtime_error("ODRV limit reached");
-            }
+        // Administrivia
+        ++globals::instance()._odrv_count;
+
+        if (settings::instance()._max_violation_count > 0 &&
+            globals::instance()._odrv_count >= settings::instance()._max_violation_count) {
+            throw std::runtime_error("ODRV limit reached");
         }
     }
     assert(globals::instance()._odrv_count == violations.size());

--- a/src/object_file_registry.cpp
+++ b/src/object_file_registry.cpp
@@ -24,7 +24,7 @@ tbb::concurrent_vector<object_file_descriptor>& obj_registry() {
 /**************************************************************************************************/
 
 } // namespace
-    
+
 /**************************************************************************************************/
 
 std::size_t object_file_register(object_ancestry&& ancestry, file_details&& details) {
@@ -32,12 +32,11 @@ std::size_t object_file_register(object_ancestry&& ancestry, file_details&& deta
     // "Growing the container does not invalidate any existing iterators or indices."
     // https://spec.oneapi.io/versions/latest/elements/oneTBB/source/containers/concurrent_vector_cls.html
 
-    auto result = obj_registry().emplace_back(object_file_descriptor{std::move(ancestry), std::move(details)});
+    auto result = obj_registry().emplace_back(
+        object_file_descriptor{std::move(ancestry), std::move(details)});
     return std::distance(obj_registry().begin(), result);
 }
 
-const object_file_descriptor& object_file_fetch(std::size_t index) {
-    return obj_registry()[index];
-}
+const object_file_descriptor& object_file_fetch(std::size_t index) { return obj_registry()[index]; }
 
 /**************************************************************************************************/

--- a/src/orc.cpp
+++ b/src/orc.cpp
@@ -517,8 +517,7 @@ std::ostream& operator<<(std::ostream& s, const odrv_report& report) {
 /**************************************************************************************************/
 
 die* enforce_odrv_for_die_list(die* base, std::vector<odrv_report>& results) {
-    // Not necessary given the slowdown from `odrv_report` constructor, below.
-    // ZoneScoped;
+    ZoneScoped;
 
     // pre-flight the vector allocation by counting the number of dies
     // we'll be storing in it.
@@ -527,7 +526,7 @@ die* enforce_odrv_for_die_list(die* base, std::vector<odrv_report>& results) {
         ++count;
     }
 
-    // ZoneValue(count);
+    ZoneValue(count);
 
     if (count == 1) return base;
 
@@ -571,8 +570,6 @@ die* enforce_odrv_for_die_list(die* base, std::vector<odrv_report>& results) {
 
     dies[0]->_conflict = true;
 
-    // The vast majority of the time in this routine is spent in the `odrv_report` constructor.
-    // Like, >99%.
     odrv_report report{path_to_symbol(base->_path.view()), dies[0]};
 
     static TracyLockable(std::mutex, odrv_report_mutex);
@@ -649,7 +646,7 @@ std::vector<odrv_report> orc_process(const std::vector<std::filesystem::path>& f
 
     work().wait();
 
-    TracyMessageL("orc_process: Sorting ODRV reports");
+    TracyMessageL("orc_process: Sorting & filtering ODRV reports");
 
     std::sort(result.begin(), result.end(),
               [](const odrv_report& a, const odrv_report& b) { return a._symbol < b._symbol; });

--- a/src/orc.cpp
+++ b/src/orc.cpp
@@ -626,13 +626,6 @@ std::vector<odrv_report> orc_process(const std::vector<std::filesystem::path>& f
     while (cur_work != work_size) {
         // All but the last chunk will be the same size.
         // The last one could be up to (chunk_count - 1) smaller.
-        //
-        // There's a chance to save some good time here, especially on larger scans.
-        // The subdivisions are equal in task size, but each task will not be the
-        // same amount of time. Thus, some workers will finish sooner than others-
-        // some by quite a bit (on the order of seconds for 10MM+ die scans.) It
-        // may be worth trying some kind of task-stealing, though I'm not quite
-        // sure what that would look like.
         const auto next_chunk_size = std::min(chunk_size, work_size - cur_work);
         const auto last = std::next(first, next_chunk_size);
         do_work([_first = first, _last = last, &result]() mutable {

--- a/src/orc.cpp
+++ b/src/orc.cpp
@@ -88,19 +88,18 @@ std::vector<dw::at> fatal_attribute_names(const attribute_sequence& x) {
     return result;
 }
 
-std::vector<dw::at> find_attribute_conflict(const attribute_sequence& x, const attribute_sequence& y) {
+std::vector<dw::at> find_attribute_conflict(const attribute_sequence& x,
+                                            const attribute_sequence& y) {
     const auto x_names = fatal_attribute_names(x);
     const auto y_names = fatal_attribute_names(y);
 
     std::vector<dw::at> result;
     std::vector<dw::at> intersection;
 
-    std::set_symmetric_difference(x_names.begin(), x_names.end(),
-                                  y_names.begin(), y_names.end(),
+    std::set_symmetric_difference(x_names.begin(), x_names.end(), y_names.begin(), y_names.end(),
                                   std::back_inserter(result));
 
-    std::set_intersection(x_names.begin(), x_names.end(),
-                          y_names.begin(), y_names.end(),
+    std::set_intersection(x_names.begin(), x_names.end(), y_names.begin(), y_names.end(),
                           std::back_inserter(intersection));
 
     const auto xf = x.begin();
@@ -313,8 +312,9 @@ void do_work(std::function<void()> f) {
 
     system([_work_token = work().working(), _doit = std::move(doit)] {
 #if ORC_FEATURE(TRACY)
-        thread_local bool tracy_set_thread_name_k = []{
-            TracyCSetThreadName(orc::tracy::format_unique("worker %s", orc::tracy::unique_thread_name()));
+        thread_local bool tracy_set_thread_name_k = [] {
+            TracyCSetThreadName(
+                orc::tracy::format_unique("worker %s", orc::tracy::unique_thread_name()));
             return true;
         }();
         (void)tracy_set_thread_name_k;
@@ -388,7 +388,8 @@ odrv_report::odrv_report(std::string_view symbol, const die* list_head)
     for (auto x = conflict_first; x != conflict_last; ++x) {
         for (auto y = std::next(x); y != conflict_last; ++y) {
             auto conflicts = find_attribute_conflict(x->second._attributes, y->second._attributes);
-            _conflicting_attributes.insert(_conflicting_attributes.end(), conflicts.begin(), conflicts.end());
+            _conflicting_attributes.insert(_conflicting_attributes.end(), conflicts.begin(),
+                                           conflicts.end());
         }
     }
 
@@ -494,7 +495,8 @@ auto sorted_keys(const MapType& map) {
 std::ostream& operator<<(std::ostream& s, const odrv_report& report) {
     const std::string_view& symbol = report._symbol;
 
-    s << problem_prefix() << ": ODRV (" << report.reporting_categories() << "); " << report.conflict_map().size() << " conflicts with `"
+    s << problem_prefix() << ": ODRV (" << report.reporting_categories() << "); "
+      << report.conflict_map().size() << " conflicts with `"
       << (symbol.data() ? demangle(symbol.data()) : "<unknown>") << "`\n";
     const auto& conflicts = report.conflict_map();
     for (const auto& entry : sorted_keys(conflicts)) {
@@ -505,7 +507,8 @@ std::ostream& operator<<(std::ostream& s, const odrv_report& report) {
         s << "    symbol defintion location(s):\n";
         for (const auto& entry : sorted_keys(locations)) {
             const auto& instances = locations.at(entry);
-            s << "        " << entry << " (used by `" << instances.front() << "` and " << (instances.size() - 1) << " others)\n";
+            s << "        " << entry << " (used by `" << instances.front() << "` and "
+              << (instances.size() - 1) << " others)\n";
         }
         s << '\n';
     }
@@ -574,8 +577,8 @@ die* enforce_odrv_for_die_list(die* base, std::vector<odrv_report>& results) {
 
     static TracyLockable(std::mutex, odrv_report_mutex);
     {
-    std::lock_guard<LockableBase(std::mutex)> lock(odrv_report_mutex);
-    results.push_back(report);
+        std::lock_guard<LockableBase(std::mutex)> lock(odrv_report_mutex);
+        results.push_back(report);
     }
 
     return dies.front();

--- a/src/orc.cpp
+++ b/src/orc.cpp
@@ -463,18 +463,13 @@ std::string odrv_report::category(std::size_t n) const {
 }
 
 /**************************************************************************************************/
-// Here we have an ODRV report, but need to decide if the ODRV's categories are ones we should
-// report for, or if we should filter this ODRV out of the report.
-bool filter_report(const odrv_report& report) {
-    std::vector<std::string> categories;
-    for (std::size_t i = 0; i < report.category_count(); ++i) {
-        categories.push_back(report.category(i));
-    }
-
+// Given an ODRV report, we need to decide if the report's categories are ones we should
+// report for, or if we should filter this report out.
+bool emit_report(const odrv_report& report) {
     // The general rule here is that if any category is
     // marked "report", we issue the ODRV report.
-    for (const auto& category : categories) {
-        if (should_report_category(category)) {
+    for (std::size_t i = 0; i < report.category_count(); ++i) {
+        if (should_report_category(report.category(i))) {
             return true;
         }
     }
@@ -532,7 +527,7 @@ die* enforce_odrv_for_die_list(die* base, std::vector<odrv_report>& results) {
         ++count;
     }
 
-    ZoneValue(count);
+    // ZoneValue(count);
 
     if (count == 1) return base;
 

--- a/src/orc.cpp
+++ b/src/orc.cpp
@@ -503,21 +503,10 @@ std::ostream& operator<<(std::ostream& s, const odrv_report& report) {
         const auto& locations = conflict._locations;
 
         s << conflict._attributes;
-        s << "    locations:\n";
+        s << "    symbol defintion location(s):\n";
         for (const auto& entry : keys(locations)) {
             const auto& instances = locations.at(entry);
-            s << "        " << entry << "(" << instances.size() << "):\n";
-            s << "            ";
-            bool first = true;
-            for (const auto& instance : instances) {
-                if (first) {
-                    first = false;
-                } else {
-                    s << ", ";
-                }
-                s << instance;
-            }
-            s << '\n';
+            s << "        " << entry << " (used by `" << instances.front() << "` and " << (instances.size() - 1) << " others)\n";
         }
         s << '\n';
     }

--- a/src/parse_file.cpp
+++ b/src/parse_file.cpp
@@ -78,9 +78,7 @@ file_details detect_file(freader& s) {
             } else if (cputype == CPU_TYPE_ARM64_32) {
                 result._arch = arch::arm64;
             } else {
-                cerr_safe([&](auto& s) {
-                    s << "WARN: Unknown Mach-O cputype\n";
-                });
+                cerr_safe([&](auto& s) { s << "WARN: Unknown Mach-O cputype\n"; });
             }
         }
 

--- a/src/string_pool.cpp
+++ b/src/string_pool.cpp
@@ -38,7 +38,9 @@ namespace {
 
 /**************************************************************************************************/
 
-std::size_t string_view_hash(std::string_view s) { return orc::murmur3_64(s.data(), static_cast<std::uint32_t>(s.length())); }
+std::size_t string_view_hash(std::string_view s) {
+    return orc::murmur3_64(s.data(), static_cast<std::uint32_t>(s.length()));
+}
 
 /**************************************************************************************************/
 
@@ -103,9 +105,9 @@ struct pool {
 /**************************************************************************************************/
 
 #if ORC_FEATURE(PROFILE_POOL_MUTEXES)
-    using string_pool_mutex = LockableBase(std::mutex);
+using string_pool_mutex = LockableBase(std::mutex);
 #else
-    using string_pool_mutex = std::mutex;
+using string_pool_mutex = std::mutex;
 #endif // ORC_FEATURE(PROFILE_POOL_MUTEXES)
 
 /**************************************************************************************************/
@@ -121,10 +123,11 @@ auto& pool_mutex(std::size_t index) {
     // in place, which makes them very difficult to construct as a contiguous collection. So
     // we allocate them dynamically and collect their pointers as a contiguous sequence, then
     // index and dereference one of the pointers.
-    static string_pool_mutex** mutexes = []{
+    static string_pool_mutex** mutexes = [] {
         static std::vector<string_pool_mutex*> result;
         for (std::size_t i(0); i < string_pool_count_k; ++i) {
-            static constexpr tracy::SourceLocationData srcloc { nullptr, "pool_mutex", TracyFile, TracyLine, 0 };
+            static constexpr tracy::SourceLocationData srcloc{nullptr, "pool_mutex", TracyFile,
+                                                              TracyLine, 0};
             result.emplace_back(new string_pool_mutex(&srcloc));
         }
         return &result[0];
@@ -137,7 +140,7 @@ auto& pool_mutex(std::size_t index) {
 }
 
 auto& pool(std::size_t index) {
-    static struct pool* pools = []{
+    static struct pool* pools = [] {
         static struct pool result[string_pool_count_k];
 
 #if ORC_FEATURE(PROFILE_POOL_MEMORY)

--- a/src/tracy.cpp
+++ b/src/tracy.cpp
@@ -69,7 +69,7 @@ void initialize() {
         // The workaround is to connect the analyzer or preempt the application. In either
         // case, you're not losing profiling data.
         while (!profiler.HasShutdownFinished()) {
-            static bool do_once = []{
+            static bool do_once = [] {
                 std::cout << "Waiting for Tracy...\n";
                 return true;
             }();

--- a/test/battery/calling_convention/odrv_test.toml
+++ b/test/battery/calling_convention/odrv_test.toml
@@ -13,11 +13,11 @@
     ]
 
 [[odrv]]
-    category = "structure:calling_convention"
+    category = "structure:byte_size, structure:calling_convention"
     symbol = "object"
 
 [[odrv]]
-    category = "subprogram:virtuality"
+    category = "subprogram:virtuality, subprogram:vtable_elem_location"
     symbol = "object::api() const"
 
 [orc_test_flags]

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -381,7 +381,7 @@ std::vector<expected_odrv> derive_expected_odrvs(const std::filesystem::path& ho
 /**************************************************************************************************/
 
 bool odrv_report_match(const expected_odrv& odrv, const odrv_report& report) {
-    if (odrv.category() != report.category()) {
+    if (odrv.category() != report.reporting_categories()) {
         return false;
     }
 
@@ -480,7 +480,7 @@ void run_battery_test(const std::filesystem::path& home) {
                 break;
             }
 
-            console() << "    Found expected ODRV: " << report.category() << "\n";
+            console() << "    Found expected ODRV: " << report.reporting_categories() << "\n";
         }
     }
 


### PR DESCRIPTION
This PR includes a wide number of changes to improve the determinism and breadth of ODRV reporting. The reports are becoming quite dense, but that is purposeful to maximize a report's signal to noise ratio. To make it easier to explain what's all in here, let's break down a sample report:

```
error: ODRV (member:data_member_location, member:type); 4 conflicts with `example::symbol`
    name: symbol
    type: `unsigned short***`
    data_member_location: 56 (0x38)
    symbol defintion location(s):
        /path/to/lib16/lib16.h:818 (used by `somelib.a -> a16.o` and 4 others)

    name: symbol
    type: `unsigned short***`
    data_member_location: 64 (0x40)
    symbol defintion location(s):
        /path/to/lib16/lib16.h:818 (used by `otherlib16.a -> b.o` and 55 others)

    name: symbol
    type: `short***`
    data_member_location: 56 (0x38)
    symbol defintion location(s):
        /path/to/lib12/lib12.h:813 (used by `somelib.a -> a12.o` and 1 others)

    name: symbol
    type: `unsigned char***`
    data_member_location: 56 (0x38)
    symbol defintion location(s):
        /path/to/lib8/lib8.h:813 (used by `somelib.a -> c.o` and 2 others)


error: ODRV (member:data_member_location); 2 conflicts with `example::other_symbol`
    name: other_symbol
    type: `short***`
    data_member_location: 72 (0x48)
    symbol defintion location(s):
        /path/to/lib16/lib16.h:823 (used by `otherlib16.a -> a.o` and 55 others)

    name: other_symbol
    type: `short***`
    data_member_location: 64 (0x40)
    symbol defintion location(s):
        /path/to/lib16/lib16.h:823 (used by `somelib.a -> a16.o` and 4 others)
        /path/to/lib12/lib12.h:818 (used by `somelib.a -> a12.o` and 1 others)
        /path/to/lib8/lib8.h:818 (used by `somelib.a -> c.o` and 2 others)

Filtered out 52 ODRVs in the following categories:
    structure:calling_convention
    subprogram:accessibility
    subprogram:artificial
    subprogram:explicit_
    typedef:type
```

Here are the most significant changes:

- **We now report on multiple categories, not just one.** For a given symbol, it is possible to have definitions that conflict in multiple categories. Previously we'd pick only one category and decide if the ODRV should be filtered out or reported on, even if other categories should be reported on. The new reports now list _all_ the categories where there are any conflicts. (In the case above, `member:data_member_location, member:type`).
- **We enumerate the symbol definition location(s)**. ODR does allow for symbols to be defined in different places with some strict requirements. So it is not an ODRV necessarily when definitions are sourced from different places. However, when we do find an ODRV, we can separate those definitions based on how they differ. We also include an example object file that uses an instance of this symbol definition, along with a count of other instances that use it, too.
- **We enumerate the ODRVs that were filtered out.** This gives report readers confidence that there are no false negatives slipping by & allowing them to fine-tune ORC's reporting settings.