### PR TITLE
Hotfix: Crash when parsing two object files

### DIFF
--- a/include/orc/dwarf.hpp
+++ b/include/orc/dwarf.hpp
@@ -18,15 +18,15 @@
 using die_pair = std::tuple<die, attribute_sequence>;
 
 struct dwarf {
-    dwarf(std::uint32_t ofd_index,
-          freader&& s,
-          file_details&& details);
+    dwarf(std::uint32_t ofd_index, freader&& s, file_details&& details);
 
     void register_section(std::string name, std::size_t offset, std::size_t size);
 
     void process_all_dies();
 
-    die_pair fetch_one_die(std::size_t debug_info_offset, std::size_t cu_address);
+    die_pair fetch_one_die(std::size_t die_offset,
+                           std::size_t cu_header_offset,
+                           std::size_t cu_die_offset);
 
 private:
     struct implementation;

--- a/include/orc/dwarf_structs.hpp
+++ b/include/orc/dwarf_structs.hpp
@@ -339,18 +339,27 @@ std::ostream& operator<<(std::ostream& s, const object_ancestry& x);
 // attribute values with data taken from _debug_info. Thus it is possible for more than one die to
 // use the same abbreviation, but because the die is listed in a different place in the debug_info
 // data block, it's values will be different than previous "stampings" of the abbreviation.
+//
+// A NOTE ON ADDRESS V. OFFSET (because I keep confusing myself)
+//     * An ADDRESS is absolute relative to the _top of the file_. Address-based variables
+//       are always relative to the top of the file, so need no additional annotation.
+//     * An OFFSET is relative to either __debug_info or the start of the compilation unit
+//       (whose offset is relative to __debug_info.) Offsets should always be annotated with
+//       what their value is relative to.
+// All DWARF/DIE/scanning related variables should follow the above conventions.
 struct die {
     // Because the quantity of these created at runtime can beon the order of millions of instances,
     // these are ordered for optimal alignment. If you change the ordering, or add/remove items
     // here, please consider alignment issues.
     pool_string _path;
     die* _next_die{nullptr};
+    std::optional<location> _location; // file_decl and file_line, if they exit for the die.
     std::size_t _hash{0};
     std::size_t _fatal_attribute_hash{0};
     std::uint32_t _ofd_index{0}; // object file descriptor index
-    std::size_t _cu_die_address{0}; // address of associated compilation unit die entry
-    std::uint32_t _debug_info_offset{0}; // relative from top of __debug_info
-    std::optional<location> _location; // file_decl and file_line, if they exit for the die.
+    std::size_t _cu_header_offset{0}; // offset to the compilation unit that contains this die; relative to __debug_info
+    std::size_t _cu_die_offset{0}; // offset to the associated compilation unit die entry; relative to __debug_info
+    std::size_t _offset{0}; // offset of this die; relative to __debug_info
     dw::tag _tag{dw::tag::none};
     arch _arch{arch::unknown};
     bool _has_children{false};

--- a/include/orc/parse_file.hpp
+++ b/include/orc/parse_file.hpp
@@ -33,7 +33,7 @@ struct freader {
 
     std::size_t size() const {
         assert(*this);
-        return _l - _p;
+        return _l - _f;
     }
 
     std::size_t tellg() const {
@@ -55,7 +55,7 @@ struct freader {
                 _p += offset;
             } break;
             case std::ios::end: {
-                _p = _f + (size() - offset);
+                _p = _l - offset;
             } break;
             default: {
                 // GNU's libstdc++ has an end-of-options marker that the compiler

--- a/src/macho.cpp
+++ b/src/macho.cpp
@@ -7,6 +7,9 @@
 // identity
 #include "orc/macho.hpp"
 
+// stdc++
+#include <sstream>
+
 // mach-o
 #include <mach-o/loader.h>
 #include <mach-o/nlist.h>

--- a/src/orc.cpp
+++ b/src/orc.cpp
@@ -179,11 +179,11 @@ attribute_sequence fetch_attributes_for_die(const die& d) {
 
     auto dwarf = dwarf_from_macho(d._ofd_index, macho_params{macho_reader_mode::odrv_reporting});
 
-    auto [die, attributes] = dwarf.fetch_one_die(d._debug_info_offset, d._cu_die_address);
+    auto [die, attributes] = dwarf.fetch_one_die(d._offset, d._cu_header_offset, d._cu_die_offset);
     assert(die._tag == d._tag);
     assert(die._arch == d._arch);
     assert(die._has_children == d._has_children);
-    assert(die._debug_info_offset == d._debug_info_offset);
+    assert(die._offset == d._offset);
     return std::move(attributes);
 }
 


### PR DESCRIPTION
@bheath-adobe found a pair of object files that was causing ORC to crash. This set of changes fixes the crash.

Details of the changes:

- The compilation unit header offset is now passed to `fetch_one_die`. It was assuming the top of `__debug_info` sufficed for this value, which is true for the first compilation unit in the `.o` file. (Most `.o` files have a single compilation unit, so this "worked".) One of the sample files @bheath-adobe gave me has _multiple_ compilation units in the `.o` file, and one of the successive ones was needed for ODRV processing. This caused `fetch_one_die` to crash trying to read from the top of `__debug_info` when it should have been reading relative to the successive compilation unit header when trying to resolve a type.
  -  I also made improvements to distinguish between the offset to the compilation unit _header_ and the offset to the compilation unit _die_, which are two related but separate things.
- `refN` attribute values are now calculated relative to the compilation unit header offset (which itself is relative to the top of `__debug_info`). This used to be a value calculated very strangely; the new calculation is exactly what the DWARF spec expects should happen.
- The internal terminology around variables named "address"/"offset" has been improved:
  - An ADDRESS is absolute relative to the _top of the file_. Address-based variables are always relative to the top of the file, so need no additional annotation.
  - An OFFSET is relative to either `__debug_info` or the start of the compilation unit (whose offset is relative to `__debug_info`.) Offsets should always be annotated with what their value is relative to.
  - Going forward, all DWARF/DIE/scanning related variables should follow the above conventions.
- A handful of improvements were made to some `freader` routines, courtesy of @bheath-adobe.
- Improvements made to self-referential type deduction (Honestly I'm still not entirely sure what this is.)