### PR TITLE
Improved typedef handling

### DIFF
--- a/include/orc/hash.hpp
+++ b/include/orc/hash.hpp
@@ -37,7 +37,7 @@ inline std::size_t hash_combine(std::size_t seed, const T& x) {
     // This is the terminating hash_combine call when there's only one item left to hash into the
     // seed. It also serves as the combiner the other routine variant uses to generate its new
     // seed.
-    return (seed ^ x) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    return seed ^ (x + 0x9e3779b9 + (seed << 6) + (seed >> 2));
 }
 
 template <class T, class... Args>

--- a/include/orc/orc.hpp
+++ b/include/orc/orc.hpp
@@ -63,6 +63,8 @@ void register_dies(dies die_vector);
 
 std::string to_json(const std::vector<odrv_report>&);
 
+std::string version_json();
+
 } // namespace orc
 
 void orc_reset();

--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -342,7 +342,7 @@ void line_header::read(freader& s, bool needs_byteswap) {
 
 /**************************************************************************************************/
 // It is fixed to keep allocations from happening.
-constexpr const std::size_t max_names_k{32};
+constexpr std::size_t max_names_k{32};
 using fixed_attribute_array = std::array<dw::at, max_names_k>;
 
 // for an incoming set of arbitrary attributes, return the subset of those that are fatal.

--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -1536,6 +1536,16 @@ bool dwarf::implementation::skip_die(die& d, const attribute_sequence& attribute
         return true;
     }
 
+    // There are some symbols that are owned by the compiler and/or OS vendor (read: Apple)
+    // that have been observed to conflict. We skip them for our purposes, as we have no
+    // control over them.
+    if (d._path.view().find("::[u]::objc_object") == 0) {
+#if ORC_FEATURE(PROFILE_DIE_DETAILS)
+        ZoneTextL("skipping: vendor- or compiler-defined symbol");
+#endif // ORC_FEATURE(PROFILE_DIE_DETAILS)
+        return true;
+    }
+
     // lambdas are ephemeral and can't cause (hopefully) an ODRV
     if (d._path.view().find("lambda") != std::string::npos) {
 #if ORC_FEATURE(PROFILE_DIE_DETAILS)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -451,13 +451,19 @@ auto epilogue(bool exception) {
     const auto& g = globals::instance();
 
     if (g._object_file_count == 0) {
-        cout_safe([&](auto& s) {
-            const auto local_build = ORC_VERSION_STR() == std::string("local");
-            const std::string tag_url = local_build ? "" : std::string(" (https://github.com/adobe/orc/releases/tag/") + ORC_VERSION_STR() + ")";
-            s << "ORC (https://github.com/adobe/orc)\n";
-            s << "    version: " << ORC_VERSION_STR() << tag_url << '\n';
-            s << "    sha: " << ORC_SHA_STR() << '\n';
-        });
+        if (settings::instance()._output_file_mode == settings::output_file_mode::json) {
+            cout_safe([](auto& s){
+                s << orc::version_json() << '\n';
+            });
+        } else {
+            cout_safe([&](auto& s) {
+                const auto local_build = ORC_VERSION_STR() == std::string("local");
+                const std::string tag_url = local_build ? "" : std::string(" (https://github.com/adobe/orc/releases/tag/") + ORC_VERSION_STR() + ")";
+                s << "ORC (https://github.com/adobe/orc)\n";
+                s << "    version: " << ORC_VERSION_STR() << tag_url << '\n';
+                s << "    sha: " << ORC_SHA_STR() << '\n';
+            });
+        }
     } else if (log_level_at_least(settings::log_level::warning)) {
         // Make sure these values are in sync with the `synopsis` json blob in `to_json`.
         cout_safe([&](auto& s) {
@@ -510,9 +516,9 @@ void maybe_forward_to_linker(int argc, char** argv, const cmdline_results& cmdli
     } else if (cmdline._libtool_mode) {
         executable_path /= "libtool";
     } else {
-        if (log_level_at_least(settings::log_level::warning)) {
+        if (log_level_at_least(settings::log_level::verbose)) {
             cout_safe([&](auto& s) {
-                s << "warning: libtool/ld mode could not be derived; forwarding to linker disabled\n";
+                s << "verbose: libtool/ld mode could not be derived; forwarding to linker disabled\n";
             });
         }
 

--- a/src/orc.cpp
+++ b/src/orc.cpp
@@ -46,6 +46,7 @@
 #include "orc/str.hpp"
 #include "orc/string_pool.hpp"
 #include "orc/tracy.hpp"
+#include "orc/version.hpp"
 
 /**************************************************************************************************/
 
@@ -700,6 +701,15 @@ std::string to_json(const std::vector<odrv_report>& reports) {
     };
 
     return result.dump(spaces_k);
+}
+
+std::string version_json() {
+    nlohmann::json result;
+
+    result["version"] = ORC_VERSION_STR();
+    result["sha256"] = ORC_SHA_STR();
+
+    return result.dump();
 }
 
 /**************************************************************************************************/

--- a/test/battery/typedef_anonymous_struct/a.cpp
+++ b/test/battery/typedef_anonymous_struct/a.cpp
@@ -1,0 +1,4 @@
+typedef struct { double _d; } S;
+
+// Required so the compiler generates a symbol.
+int getd(S s) { return s._d; }

--- a/test/battery/typedef_anonymous_struct/b.cpp
+++ b/test/battery/typedef_anonymous_struct/b.cpp
@@ -1,0 +1,4 @@
+typedef struct {int _i;} S;
+
+// Required so the compiler generates a symbol.
+int geti(S s) { return s._i; }

--- a/test/battery/typedef_anonymous_struct/odrv_test.toml
+++ b/test/battery/typedef_anonymous_struct/odrv_test.toml
@@ -1,0 +1,9 @@
+[[source]]
+    path = "a.cpp"
+
+[[source]]
+    path = "b.cpp"
+
+[[odrv]]
+    category = "structure:byte_size"
+    symbol = "S"

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -504,19 +504,17 @@ void run_battery_test(const std::filesystem::path& home) {
 
 /**************************************************************************************************/
 
-void traverse_directory_tree(std::filesystem::path& directory) {
+void traverse_directory_tree(const std::filesystem::path& directory) {
     assert(is_directory(directory));
+
+    if (exists(directory / tomlname_k)) {
+        run_battery_test(directory);
+    }
 
     for (const auto& entry : std::filesystem::directory_iterator(directory)) {
         try {
             if (is_directory(entry)) {
-                std::filesystem::path path = entry.path();
-
-                if (exists(path / tomlname_k)) {
-                    run_battery_test(path);
-                }
-
-                traverse_directory_tree(path);
+                traverse_directory_tree(entry.path());
             }
         } catch (...) {
             console_error() << "\nIn battery " << entry.path() << ":";


### PR DESCRIPTION
Brandon caught a case where newer versions of ORC were passing over ODRVs it was previously reporting. This fix resolves it.

This change also includes a fix for #84, which required some juggling of a name from a named typedef to an unnamed struct that immediately follows it.