### PR TITLE
Many improvements to die interpretations given our explorations into `high_pc`

### DIFF
--- a/include/orc/dwarf_constants.hpp
+++ b/include/orc/dwarf_constants.hpp
@@ -106,6 +106,8 @@ enum class at : std::uint16_t {
     abstract_origin = 0x31,
     accessibility = 0x32,
     address_class = 0x33,
+    // DW_AT_artificial attribute indicates that the associated entity (e.g., a function, variable, or parameter)
+    // is compiler-generated rather than explicitly written by the programmer in the source code.
     artificial = 0x34,
     base_types = 0x35,
     calling_convention = 0x36,
@@ -114,9 +116,27 @@ enum class at : std::uint16_t {
     decl_column = 0x39,
     decl_file = 0x3a,
     decl_line = 0x3b,
+    // DW_AT_declaration indicates that the associated entity is a declaration rather than a definition.
+    // A function declaration is typically represented as a DW_TAG_subprogram entry with the attribute
+    // DW_AT_declaration set to true (or 1).
+    // It does not have attributes like DW_AT_low_pc or DW_AT_high_pc, as it does not correspond to actual code.
+    // Example:
+    // <1><0x0000003a>    DW_TAG_subprogram
+    //                     DW_AT_name                  ("myFunction")
+    //                     DW_AT_declaration           (true)
+
+    // A function implementation is also represented as a DW_TAG_subprogram entry but does not have the DW_AT_declaration attribute.
+    // Instead, it includes attributes like DW_AT_low_pc and DW_AT_high_pc (or DW_AT_ranges),
+    // which specify the address range of the function's code in memory.
+    // Example:
+    // <1><0x0000003a>    DW_TAG_subprogram
+    //                     DW_AT_name                  ("myFunction")
+    //                     DW_AT_low_pc                (0x0000000000401000)
+    //                     DW_AT_high_pc               (0x0000000000401020)
     declaration = 0x3c,
     discr_list = 0x3d,
     encoding = 0x3e,
+    // DW_AT_external attribute indicates that the corresponding entity (e.g., a variable, function, or type) has external linkage. 
     external = 0x3f,
     frame_base = 0x40,
     friend_ = 0x41,
@@ -125,6 +145,10 @@ enum class at : std::uint16_t {
     namelist_item = 0x44,
     priority = 0x45,
     segment = 0x46,
+    // DW_AT_specification attribute is used to reference a declaration of an entity
+    // (such as a function, variable, or type) that is defined elsewhere.
+    // It essentially links the current entry to its corresponding declaration,
+    // which is typically represented by a DW_TAG_subprogram, DW_TAG_variable, or similar tag.
     specification = 0x47,
     static_link = 0x48,
     type = 0x49,
@@ -525,6 +549,20 @@ enum class tag : std::uint16_t {
 
 const char* to_string(tag t);
 
+/**
+ * @brief Determines if a given DWARF tag represents a type
+ * 
+ * This function classifies whether a given DWARF tag represents a type definition
+ * or declaration. This is used to identify type-related DIEs in the DWARF debug
+ * information.
+ *
+ * @param t The DWARF tag to check
+ * 
+ * @return true if the tag represents a type, false otherwise
+ * 
+ * @pre The tag must be a valid DWARF tag
+ * @post The return value will be true for all type-related tags and false for all others
+ */
 bool is_type(tag t);
 
 /**************************************************************************************************/

--- a/src/dwarf_structs.cpp
+++ b/src/dwarf_structs.cpp
@@ -38,6 +38,14 @@ const char* to_string(arch arch) {
 void attribute::read(freader& s) {
     _name = static_cast<dw::at>(uleb128(s));
     _form = static_cast<dw::form>(uleb128(s));
+
+    // SPECREF DWARF5 225 (207) lines 11-14 --
+    // `implicit_const` is a special case where the value of the attribute we be an sleb immediately
+    // after the form. There is no value in the `debug_info` in this case. When we process this
+    // attribute in `process_form`, we'll source its value from here into the result.
+    if (_form == dw::form::implicit_const) {
+        _value.sint(sleb128(s));
+    }
 }
 
 /**************************************************************************************************/

--- a/test/battery/calling_convention/odrv_test.toml
+++ b/test/battery/calling_convention/odrv_test.toml
@@ -16,9 +16,5 @@
     category = "structure:byte_size, structure:calling_convention"
     symbol = "object"
 
-[[odrv]]
-    category = "subprogram:virtuality, subprogram:vtable_elem_location"
-    symbol = "object::api() const"
-
 [orc_test_flags]
     disable = false

--- a/test/battery/vtable_elem_location/src.cpp
+++ b/test/battery/vtable_elem_location/src.cpp
@@ -1,8 +1,8 @@
 struct object {
 #if OPTIONAL_API()
-    virtual int optional() const;
+    virtual int optional() const { return 0; }
 #endif //  OPTIONAL_API()
-    virtual int api() const;
+    virtual int api() const { return 1; }
 };
 
 static object instance;

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -63,7 +63,7 @@ auto& toml_out() {
 
 /**************************************************************************************************/
 
-} // namespace {
+} // namespace
 
 /**************************************************************************************************/
 
@@ -126,7 +126,7 @@ void error(const std::string& message,
 
 /**************************************************************************************************/
 
-} // namespace log
+} // namespace logging
 
 /**************************************************************************************************/
 
@@ -321,7 +321,7 @@ std::vector<compilation_unit> derive_compilation_units(const std::filesystem::pa
 /// improved.
 std::string sanitize(const std::filesystem::path& in) {
     std::string result = in.string();
-    auto new_end = std::remove_if(result.begin(), result.end(), [](char c){
+    auto new_end = std::remove_if(result.begin(), result.end(), [](char c) {
         return !(std::isalnum(c) || c == '/' || c == '.' || c == '_');
     });
     result.erase(new_end, result.end());
@@ -357,7 +357,8 @@ std::vector<std::filesystem::path> compile_compilation_units(const std::filesyst
             throw std::runtime_error("unexpected compilation failure");
         }
         object_files.emplace_back(std::move(temp_path));
-        console() << "    " << unit._src.filename() << " -> " << object_files.back().filename() << '\n';
+        console() << "    " << unit._src.filename() << " -> " << object_files.back().filename()
+                  << '\n';
     }
     return object_files;
 }
@@ -407,9 +408,9 @@ bool odrv_report_match(const expected_odrv& odrv, const odrv_report& report) {
     const std::string& linkage_name = demangle(odrv.linkage_name().c_str());
     if (!linkage_name.empty()) {
         const auto& die_pair = report.conflict_map().begin()->second;
-        const char* report_linkage_name = demangle(die_pair._attributes.string(dw::at::linkage_name).view().begin());
-        if (linkage_name != report_linkage_name)
-            return false;
+        const char* report_linkage_name =
+            demangle(die_pair._attributes.string(dw::at::linkage_name).view().begin());
+        if (linkage_name != report_linkage_name) return false;
     }
     return true;
 }
@@ -420,7 +421,7 @@ constexpr const char* tomlname_k = "odrv_test.toml";
 
 /**************************************************************************************************/
 
-void run_battery_test(const std::filesystem::path& home) {
+std::size_t run_battery_test(const std::filesystem::path& home) {
     static bool first_s = false;
 
     if (!first_s) {
@@ -450,7 +451,7 @@ void run_battery_test(const std::filesystem::path& home) {
 
     if (skip_test) {
         logging::notice("test disabled");
-        return;
+        return 0;
     }
 
     auto test_name = home.stem().string();
@@ -474,7 +475,8 @@ void run_battery_test(const std::filesystem::path& home) {
 
     auto reports = orc_process(std::move(object_files));
 
-    console() << "ODRVs expected: " << expected_odrvs.size() << "; reported: " << reports.size() << '\n';
+    console() << "ODRVs expected: " << expected_odrvs.size() << "; reported: " << reports.size()
+              << '\n';
 
     toml::table result;
     result.insert("expected", static_cast<toml::int64_t>(expected_odrvs.size()));
@@ -489,9 +491,7 @@ void run_battery_test(const std::filesystem::path& home) {
         for (const auto& report : reports) {
             auto found =
                 std::find_if(expected_odrvs.begin(), expected_odrvs.end(),
-                             [&](const auto& odrv) {
-                        return odrv_report_match(odrv, report);
-                });
+                             [&](const auto& odrv) { return odrv_report_match(odrv, report); });
 
             if (found == expected_odrvs.end()) {
                 unexpected_result = true;
@@ -516,29 +516,37 @@ void run_battery_test(const std::filesystem::path& home) {
             console() << ++count << ":\n" << expected << '\n';
         }
 
-        throw std::runtime_error("ODRV count mismatch");
+        console_error() << "\nIn battery " << home << ": ODRV count mismatch";
+
+        return 1;
     }
+
+    return 0;
 }
 
 /**************************************************************************************************/
 
-void traverse_directory_tree(const std::filesystem::path& directory) {
+std::size_t traverse_directory_tree(const std::filesystem::path& directory) {
     assert(is_directory(directory));
 
+    std::size_t errors = 0;
+
     if (exists(directory / tomlname_k)) {
-        run_battery_test(directory);
+        errors += run_battery_test(directory);
     }
 
     for (const auto& entry : std::filesystem::directory_iterator(directory)) {
         try {
             if (is_directory(entry)) {
-                traverse_directory_tree(entry.path());
+                errors += traverse_directory_tree(entry.path());
             }
         } catch (...) {
             console_error() << "\nIn battery " << entry.path() << ":";
             throw;
         }
     }
+
+    return errors;
 }
 
 /**************************************************************************************************/
@@ -563,15 +571,13 @@ int main(int argc, char** argv) try {
 
     test_settings()._json_mode = argc > 2 && std::string(argv[2]) == "--json_mode";
 
-    traverse_directory_tree(battery_path);
+    std::size_t errors = traverse_directory_tree(battery_path);
 
     if (test_settings()._json_mode) {
-        cout_safe([&](auto& s){
-            s << toml::json_formatter{ toml_out() } << '\n';
-        });
+        cout_safe([&](auto& s) { s << toml::json_formatter{toml_out()} << '\n'; });
     }
 
-    return EXIT_SUCCESS;
+    return errors ? EXIT_FAILURE : EXIT_SUCCESS;
 } catch (const std::exception& error) {
     logging::error(error.what(), "Fatal error");
     return EXIT_FAILURE;


### PR DESCRIPTION
- Adding documentation as we learn more about die attributes and values
- Adding use of adobe contract checks where `assert` needs to happen in release builds, too
- Adding `number` to `attribute_value` when the caller doesn't care what form the value takes on disk, and all valid values could be represented by either form.
- Improved handling of forms `loclistx` and `rnglistx` (which are starting to show in DWARF5 object files)
- Correct handling of `implicit_const` in a debug abbreviation (which is new to DWARF5)
- Better handling of `DW_AT_inline`
- Better handling of `DW_AT_declaration`
- Better handling of `DW_AT_specification`
- Improved die skipping logic when we are confident a die cannot contribute to ODRVs.
- Improved behaviors in orc_test, especially around running the rest of a test battery when one test fails.