### PR TITLE
Fixes #63. Replace `partition` with `erase_if` for better performance

### DIFF
--- a/src/orc.cpp
+++ b/src/orc.cpp
@@ -624,7 +624,7 @@ void register_dies(dies die_vector) {
 
     // Erase the skippable dies and shrink the vector to fit, which will preserve only the necessary
     // dies in a vector whose memory consumption is exactly what's needed.
-    std::size_t skip_count = std::erase_if(die_vector, std::mem_fn(&die::_skippable));
+    globals::instance()._die_skipped_count += std::erase_if(die_vector, std::mem_fn(&die::_skippable));
     die_vector.shrink_to_fit();
 
     // This is a list so the die vectors don't move about. The dies become pretty entangled as they
@@ -658,8 +658,6 @@ void register_dies(dies die_vector) {
         d._next_die = d_in_map._next_die;
         d_in_map._next_die = &d;
     }
-
-    globals::instance()._die_skipped_count += skip_count;
 }
 
 /**************************************************************************************************/

--- a/src/orc.cpp
+++ b/src/orc.cpp
@@ -622,17 +622,9 @@ void register_dies(dies die_vector) {
 
     globals::instance()._die_processed_count += die_vector.size();
 
-    // pre-process the vector of dies by partitioning them into those that are skippable and those
-    // that are not. Then, we erase the skippable ones and shrink the vector to fit, which will
-    // cause a reallocation and copying of only the necessary dies into a vector whose memory
-    // consumption is exactly what's needed.
-
-    auto unskipped_end =
-        std::partition(die_vector.begin(), die_vector.end(), std::not_fn(&die::_skippable));
-
-    std::size_t skip_count = std::distance(unskipped_end, die_vector.end());
-
-    die_vector.erase(unskipped_end, die_vector.end());
+    // Erase the skippable dies and shrink the vector to fit, which will preserve only the necessary
+    // dies in a vector whose memory consumption is exactly what's needed.
+    std::size_t skip_count = std::erase_if(die_vector, std::mem_fn(&die::_skippable));
     die_vector.shrink_to_fit();
 
     // This is a list so the die vectors don't move about. The dies become pretty entangled as they


### PR DESCRIPTION
One of the first things `register_dies` does is remove all dies that are flagged as "skippable" (via checking the `_skippable` member field of each). The current implementation uses `std::partition` for this, swapping the skippable entries to the latter half of the `die_vector`, then deleting that half.

This new implementation replaces `std::partition` with [`std::erase_if`](https://en.cppreference.com/w/cpp/container/vector/erase2), which uses [`std::remove_if`](https://en.cppreference.com/w/cpp/algorithm/remove) under the hood. The difference is subtle, in that `remove_if` does not care about the state of the elements being removed. As such, they are not swapped like in partition's case, but rather moved-from. This provides a slight performance improvement, which would normally not be worth writing home about. However in this case, given the sheer size of some `die_vector`s, the win could be noticeable.