### PR TITLE
Fix for `<unsupported file index>` issue with DWARF5 debug data

### DIFF
--- a/include/orc/dwarf.hpp
+++ b/include/orc/dwarf.hpp
@@ -18,6 +18,8 @@
 using die_pair = std::tuple<die, attribute_sequence>;
 
 struct dwarf {
+    struct implementation;
+
     dwarf(std::uint32_t ofd_index, freader&& s, file_details&& details);
 
     void register_section(std::string name, std::size_t offset, std::size_t size);
@@ -29,7 +31,6 @@ struct dwarf {
                            std::size_t cu_die_offset);
 
 private:
-    struct implementation;
     std::unique_ptr<implementation, void (*)(implementation*)> _impl{nullptr,
                                                                      [](implementation*) {}};
 };

--- a/include/orc/dwarf_constants.hpp
+++ b/include/orc/dwarf_constants.hpp
@@ -791,6 +791,18 @@ enum class encoding_class {
 encoding_class attribute_encoding_class(at attribute);
 
 //--------------------------------------------------------------------------------------------------
+// SPECREF: DWARF5 page 255 (237) line 2
+enum class lnct : std::uint16_t {
+    path = 0x1,
+    directory_index = 0x2,
+    timestamp = 0x3,
+    size = 0x4,
+    md5 = 0x5,
+    lo_user = 0x2000,
+    hi_user = 0x3fff,
+};
+
+//--------------------------------------------------------------------------------------------------
 
 } // namespace dw
 

--- a/include/orc/parse_file.hpp
+++ b/include/orc/parse_file.hpp
@@ -13,6 +13,9 @@
 #include <iostream>
 #include <type_traits>
 
+// adobe contract checks
+#include "adobe/contract_checks.hpp"
+
 // application
 #include "orc/dwarf_structs.hpp"
 #include "orc/hash.hpp"
@@ -32,18 +35,18 @@ struct freader {
     explicit operator bool() const { return static_cast<bool>(_buffer) && _p <= _l; }
 
     std::size_t size() const {
-        assert(*this);
+        ADOBE_INVARIANT(*this);
         return _l - _f;
     }
 
     std::size_t tellg() const {
-        assert(*this);
+        ADOBE_INVARIANT(*this);
         return _p - _f;
     }
 
     void seekg(std::istream::off_type offset) {
         _p = _f + offset;
-        assert(*this);
+        ADOBE_INVARIANT(*this);
     }
 
     void seekg(std::istream::off_type offset, std::ios::seekdir dir) {
@@ -61,21 +64,21 @@ struct freader {
                 // GNU's libstdc++ has an end-of-options marker that the compiler
                 // will complain about as being unhandled here. It should *never*
                 // be used as a valid value for this enumeration.
-                assert(false);
+                ADOBE_INVARIANT(false);
             } break;
         }
-        assert(*this);
+        ADOBE_INVARIANT(*this);
     }
 
     void read(char* p, std::size_t n) {
         std::memcpy(p, _p, n);
         _p += n;
-        assert(*this);
+        ADOBE_INVARIANT(*this);
     }
 
     char get() {
         char result = *_p++;
-        assert(*this);
+        ADOBE_INVARIANT(*this);
         return result;
     }
 
@@ -84,7 +87,7 @@ struct freader {
         for (; *_p; ++_p) {
         }
         auto n = _p++ - f;
-        assert(*this);
+        ADOBE_INVARIANT(*this);
         return std::string_view(f, n);
     }
 
@@ -134,12 +137,10 @@ auto read_exactly(freader& s, std::size_t size, F&& f) {
     auto start = s.tellg();
     if constexpr (std::is_same<std::invoke_result_t<F, std::size_t>, void>::value) {
         std::forward<F>(f)(size);
-        assert(s.tellg() == start + size);
-        if (s.tellg() != start + size) throw std::runtime_error("read_exactly failure");
+        ADOBE_INVARIANT(s.tellg() == start + size);
     } else {
         auto result = std::forward<F>(f)(size);
-        assert(s.tellg() == start + size);
-        if (s.tellg() != start + size) throw std::runtime_error("read_exactly failure");
+        ADOBE_INVARIANT(s.tellg() == start + size);
         return result;
     }
 }

--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -295,18 +295,23 @@ void abbrev::read(freader& s) {
 
 //--------------------------------------------------------------------------------------------------
 
+using md5_hash = std::array<std::uint8_t, 16>;
+
+//--------------------------------------------------------------------------------------------------
 /**
  * @brief Represents a source file entry in DWARF debug information
  * 
  * This struct stores information about a source file referenced in the DWARF
  * debug information, including its name, directory index, modification time,
- * and length.
+ * and length. Used to represent both directories and file names in the
+ * compilation header.
  */
 struct file_name {
-    std::string_view _name; ///< The name of the source file
+    pool_string _name; ///< The name of the source file
     std::uint32_t _directory_index{0}; ///< Index into the include directories list
     std::uint32_t _mod_time{0}; ///< File modification time
     std::uint32_t _file_length{0}; ///< Length of the file in bytes
+    md5_hash _md5{0}; ///< MD5 hash of the source file
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -467,9 +472,11 @@ void cu_header::read(freader& s, bool needs_byteswap) {
  * This struct stores information from a DWARF line number program header,
  * which contains metadata about how line number information is encoded
  * in the debug information. For ORC's purposes, this is largely ignored
- * except for `_file_names` and `_include_directories`.
+ * except for `_file_names` and `include_directories`.
  */
 struct line_header {
+    using content_form_pair = std::pair<dw::lnct, dw::form>;
+
     // DWARF spec section 6.2.4 The Line Number Program Header.
     // Note this will change for DWARF5, so we need to look out
     // for DWARF data that uses the new version number and
@@ -486,7 +493,13 @@ struct line_header {
     std::uint32_t _line_range{0}; ///< Range of line numbers
     std::uint32_t _opcode_base{0}; ///< Base value for opcodes
     std::vector<std::uint32_t> _standard_opcode_lengths; ///< Lengths of standard opcodes
-    std::vector<std::string_view> _include_directories; ///< Include directories
+    std::uint8_t _directory_entry_format_count{0}; // DWARF5
+    std::vector<content_form_pair> _directory_entry_format; // DWARF5
+    std::uint32_t _directories_count{0}; // DWARF5
+    std::vector<file_name> _directories; ///< Include directories
+    std::uint8_t _file_name_entry_format_count{0}; // DWARF5
+    std::vector<content_form_pair> _file_name_entry_format; // DWARF5
+    std::uint32_t _file_names_count{0}; // DWARF5
     std::vector<file_name> _file_names; ///< Source file names
 
     /**
@@ -501,73 +514,21 @@ struct line_header {
      * @pre The file reader must be positioned at the start of a line number program header
      * @post The file reader will be positioned after the header
      */
-    void read(freader& s, bool needs_byteswap);
+    void read(dwarf::implementation& dwarf);
+
+    void read_all_path_contents(dwarf::implementation& dwarf,
+                                std::uint8_t& format_count,
+                                std::vector<content_form_pair>& formats,
+                                std::uint32_t& path_count,
+                                std::vector<file_name>& paths);
+
+    file_name read_one_path_content(dwarf::implementation& dwarf,
+                                    const std::vector<content_form_pair>& formats);
+
+    pool_string read_one_path_content_path(dwarf::implementation& dwarf, dw::form form);
+    std::uint32_t read_one_path_content_directory_index(dwarf::implementation& dwarf, dw::form form);
+    md5_hash read_one_path_content_md5(dwarf::implementation& dwarf, dw::form form);
 };
-
-//--------------------------------------------------------------------------------------------------
-
-void line_header::read(freader& s, bool needs_byteswap) {
-    _length = read_pod<std::uint32_t>(s, needs_byteswap);
-    if (_length >= 0xfffffff0) {
-        // REVISIT: (fbrereto) handle extended length / DWARF64
-        throw std::runtime_error("unsupported length");
-    }
-    _version = read_pod<std::uint16_t>(s, needs_byteswap);
-    if (_version == 2) {
-        // Do nothing. DWARF2 has been found in some cases
-        // and the current implementation seems to suffice.
-    } else if (_version == 4) {
-        // Do nothing. We started this project with DWARF4
-        // so the baseline implementation should match that.
-    } else if (_version == 5) {
-        // SPECREF: DWARF5 page 26 (8) line 11 -- changes from DWARF4 to DWARF5
-
-        // SPECREF: DWARF5 page 172 (154) line 10
-        _address_size = read_pod<std::int8_t>(s, needs_byteswap);
-
-        // SPECREF: DWARF5 page 172 (154) line 16
-        _segment_selector_size = read_pod<std::int8_t>(s, needs_byteswap);
-    } else {
-        ADOBE_INVARIANT(!"unhandled DWARF line header");
-    }
-    _header_length = read_pod<std::uint32_t>(s, needs_byteswap);
-    _min_instruction_length = read_pod<std::uint8_t>(s);
-    if (_version >= 4) {
-        _max_ops_per_instruction = read_pod<std::uint8_t>(s);
-    }
-    _default_is_statement = read_pod<std::uint8_t>(s);
-    _line_base = read_pod<std::int8_t>(s);
-    _line_range = read_pod<std::uint8_t>(s);
-    _opcode_base = read_pod<std::uint8_t>(s);
-
-    for (std::size_t i{0}; i < (_opcode_base - 1); ++i) {
-        _standard_opcode_lengths.push_back(read_pod<std::int8_t>(s));
-    }
-
-    while (true) {
-        auto cur_directory = s.read_c_string_view();
-        if (cur_directory.empty()) break;
-        _include_directories.push_back(cur_directory);
-    }
-
-    // REVIST (fosterbrereton): The reading here isn't entirely accurate. The current code stops the
-    // first time an empty name is found, and interprets that as the end of the file names (and thus
-    // the `line_header`). However, the spec (as the end of section 6.2.4) states "A compiler may
-    // generate a single null byte for the file names field and define file names using the
-    // extended opcode DW_LNE_define_file." This loop, then, should iterate through the end of the
-    // defined size of `_header_length` instead of using an empty name as a sentry. Any additional
-    // null bytes should be interpreted as a placeholder file name description. (Admittedly, I
-    // haven't seen one of these in the wild yet.)
-    while (true) {
-        file_name cur_file_name;
-        cur_file_name._name = s.read_c_string_view();
-        if (cur_file_name._name.empty()) break;
-        cur_file_name._directory_index = uleb128(s);
-        cur_file_name._mod_time = uleb128(s);
-        cur_file_name._file_length = uleb128(s);
-        _file_names.push_back(std::move(cur_file_name));
-    }
-}
 
 //--------------------------------------------------------------------------------------------------
 // It is fixed to keep allocations from happening.
@@ -720,6 +681,7 @@ struct dwarf::implementation {
     const abbrev& find_abbreviation(std::uint32_t code) const;
 
     pool_string read_debug_str(std::size_t offset);
+    pool_string read_debug_line_str(std::size_t offset);
     pool_string read_debug_str_offs(std::size_t offset);
 
     void path_identifier_push();
@@ -753,6 +715,7 @@ struct dwarf::implementation {
     std::vector<pool_string> _decl_files;
     std::unordered_map<std::size_t, pool_string> _type_cache;
     std::unordered_map<std::size_t, pool_string> _debug_str_cache;
+    std::unordered_map<std::size_t, pool_string> _debug_line_str_cache;
     std::unordered_map<std::size_t, pool_string> _debug_str_offs_cache;
     pool_string _last_typedef_name; // for unnamed structs - see https://github.com/adobe/orc/issues/84
     cu_header _cu_header;
@@ -763,6 +726,7 @@ struct dwarf::implementation {
     section _debug_abbrev;
     section _debug_info;
     section _debug_line;
+    section _debug_line_str;
     section _debug_str;
     section _debug_str_offsets;
     bool _ready{false};
@@ -835,6 +799,8 @@ void dwarf::implementation::register_section(const std::string& name,
         _debug_abbrev = section{offset, size};
     } else if (name == "__debug_line") {
         _debug_line = section{offset, size};
+    } else if (name == "__debug_line_str__DWARF") {
+        _debug_line_str = section{offset, size};
     } else if (name == "__debug_str_offs__DWARF") {
         _debug_str_offsets = section{offset, size};
     } else {
@@ -871,17 +837,17 @@ void dwarf::implementation::read_lines(std::size_t header_offset) {
 
     temp_seek(_s, _debug_line._offset + header_offset, [&] {
         line_header header;
-        header.read(_s, _details._needs_byteswap);
+        header.read(*this);
 
         for (const auto& name : header._file_names) {
             if (name._directory_index > 0) {
-                ADOBE_INVARIANT(name._directory_index - 1 < header._include_directories.size());
-                std::string path(header._include_directories[name._directory_index - 1]);
+                ADOBE_INVARIANT(name._directory_index - 1 < header._directories.size());
+                std::string path = header._directories[name._directory_index - 1]._name.allocate_string();
                 path += '/';
-                path += name._name;
+                path += name._name.allocate_string();
                 _decl_files.push_back(empool(path));
             } else {
-                _decl_files.push_back(empool(name._name));
+                _decl_files.push_back(name._name);
             }
         }
 
@@ -945,6 +911,17 @@ pool_string dwarf::implementation::read_debug_str(std::size_t offset) {
 
     return _debug_str_cache[offset] = temp_seek(_s, _debug_str._offset + offset,
                                                 [&] { return empool(_s.read_c_string_view()); });
+}
+
+//--------------------------------------------------------------------------------------------------
+
+pool_string dwarf::implementation::read_debug_line_str(std::size_t offset) {
+    if (const auto found = _debug_line_str_cache.find(offset); found != _debug_line_str_cache.end()) {
+        return found->second;
+    }
+
+    return _debug_line_str_cache[offset] = temp_seek(_s, _debug_line_str._offset + offset,
+                                                     [&] { return empool(_s.read_c_string_view()); });
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -2459,6 +2436,196 @@ die_pair dwarf::implementation::fetch_one_die(std::size_t die_offset,
 
     return result;
 }
+
+//--------------------------------------------------------------------------------------------------
+
+namespace {
+
+//--------------------------------------------------------------------------------------------------
+
+pool_string line_header::read_one_path_content_path(dwarf::implementation& dwarf, dw::form form) {
+    // SPECREF DWARF5 176 (158) lines 16-37
+    switch (form) {
+        case dw::form::string: {
+            return empool(dwarf._s.read_c_string_view());
+        } break;
+        case dw::form::strp: {
+            return dwarf.read_debug_str(dwarf.read32());
+        } break;
+        case dw::form::line_strp: {
+            return dwarf.read_debug_line_str(dwarf.read32());
+        } break;
+        default: {
+            ADOBE_INVARIANT(!"read_one_path_content_path: unhandled form");
+        } break;
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+
+std::uint32_t line_header::read_one_path_content_directory_index(dwarf::implementation& dwarf, dw::form form) {
+    // SPECREF DWARF5 177 (159) lines 1-11
+    switch (form) {
+        case dw::form::data1: {
+            return dwarf.read8();
+        } break;
+        case dw::form::data2: {
+            return dwarf.read16();
+        } break;
+        case dw::form::udata: {
+            return dwarf.read_uleb();
+        } break;
+        default: {
+            ADOBE_INVARIANT(!"read_one_path_content_directory_index: unhandled form");
+        } break;
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+
+md5_hash line_header::read_one_path_content_md5(dwarf::implementation& dwarf, dw::form form) {
+    md5_hash result{0};
+    dwarf._s.read(reinterpret_cast<char*>(&result[0]), 16);
+    return result;
+}
+
+//--------------------------------------------------------------------------------------------------
+
+file_name line_header::read_one_path_content(dwarf::implementation& dwarf,
+                                             const std::vector<content_form_pair>& formats) {
+    file_name result;
+    for (const auto& format : formats) {
+        switch (format.first) {
+            case dw::lnct::path: {
+                result._name = read_one_path_content_path(dwarf, format.second);
+            } break;
+            case dw::lnct::directory_index: {
+                result._directory_index = read_one_path_content_directory_index(dwarf, format.second);
+            } break;
+            case dw::lnct::md5: {
+                result._md5 = read_one_path_content_md5(dwarf, format.second);
+            } break;
+            default: {
+                ADOBE_INVARIANT(!"read_one_path_content: unhandled content type");
+            } break;
+        }
+    }
+    return result;
+}
+
+//--------------------------------------------------------------------------------------------------
+// SPECREF: DWARF5 page 174 (156) lines 10ff. There's a lot of new stuff here with DWARF5.
+// This routine handles both directories and file names, which are structured the same.
+void line_header::read_all_path_contents(dwarf::implementation& dwarf,
+                                         std::uint8_t& format_count,
+                                         std::vector<content_form_pair>& formats,
+                                         std::uint32_t& path_count,
+                                         std::vector<file_name>& paths) {
+    // SPECREF: DWARF5 page 174 (156) lines 10ff. There's a lot of new stuff here with DWARF5.
+    format_count = dwarf.read8();
+
+    // SPECREF: DWARF5 page 339 (321) lines 2-4 --
+    // According to the example, this tells us the metadata to be specified for each of the
+    // subsequent entries to follow. Think of these similar to a die abbreviation, to be stamped
+    // out over the ensuing dies. Only this is the template for the ensuing set of directories.
+    for (std::size_t i{0}; i < format_count; ++i) {
+        // REVISIT: Add some checks here to ensure the values are valid.
+        formats.emplace_back(static_cast<dw::lnct>(dwarf.read_uleb()),
+                             static_cast<dw::form>(dwarf.read_uleb()));
+    }
+
+    // Each path will have `format_count` entries.
+    path_count = dwarf.read_uleb();
+
+    for (std::size_t i{0}; i < path_count; ++i) {
+        paths.push_back(read_one_path_content(dwarf, formats));
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+
+void line_header::read(dwarf::implementation& dwarf) {
+    _length = dwarf.read32();
+    if (_length >= 0xfffffff0) {
+        // REVISIT: (fbrereto) handle extended length / DWARF64
+        throw std::runtime_error("unsupported length");
+    }
+    _version = dwarf.read16();
+    if (_version == 2) {
+        // Do nothing. DWARF2 has been found in some cases
+        // and the current implementation seems to suffice.
+    } else if (_version == 4) {
+        // Do nothing. We started this project with DWARF4
+        // so the baseline implementation should match that.
+    } else if (_version == 5) {
+        // SPECREF: DWARF5 page 26 (8) line 11 -- changes from DWARF4 to DWARF5
+        
+        // SPECREF: DWARF5 page 172 (154) line 10
+        _address_size = dwarf.read8();
+
+        // SPECREF: DWARF5 page 172 (154) line 16
+        _segment_selector_size = dwarf.read8();
+    } else {
+        ADOBE_INVARIANT(!"unhandled DWARF line header");
+    }
+    _header_length = dwarf.read32();
+    _min_instruction_length = dwarf.read8();
+    if (_version >= 4) {
+        _max_ops_per_instruction = dwarf.read8();
+    }
+    _default_is_statement = dwarf.read8();
+    _line_base = dwarf.read8();
+    _line_range = dwarf.read8();
+    _opcode_base = dwarf.read8();
+    
+    for (std::size_t i{0}; i < (_opcode_base - 1); ++i) {
+        _standard_opcode_lengths.push_back(dwarf.read8());
+    }
+    
+    if (_version < 5) {
+        while (true) {
+            auto cur_directory = dwarf._s.read_c_string_view();
+            if (cur_directory.empty()) break;
+            file_name cur_name;
+            cur_name._name = empool(cur_directory);
+            _directories.push_back(std::move(cur_name));
+        }
+        
+        // REVIST (fosterbrereton): The reading here isn't entirely accurate. The current code stops the
+        // first time an empty name is found, and interprets that as the end of the file names (and thus
+        // the `line_header`). However, the spec (as the end of section 6.2.4) states "A compiler may
+        // generate a single null byte for the file names field and define file names using the
+        // extended opcode DW_LNE_define_file." This loop, then, should iterate through the end of the
+        // defined size of `_header_length` instead of using an empty name as a sentry. Any additional
+        // null bytes should be interpreted as a placeholder file name description. (Admittedly, I
+        // haven't seen one of these in the wild yet.)
+        while (true) {
+            file_name cur_file_name;
+            cur_file_name._name = empool(dwarf._s.read_c_string_view());
+            if (cur_file_name._name.empty()) break;
+            cur_file_name._directory_index = dwarf.read_uleb();
+            cur_file_name._mod_time = dwarf.read_uleb();
+            cur_file_name._file_length = dwarf.read_uleb();
+            _file_names.push_back(std::move(cur_file_name));
+        }
+    } else {
+        read_all_path_contents(dwarf,
+                               _directory_entry_format_count,
+                               _directory_entry_format,
+                               _directories_count,
+                               _directories);
+        
+        read_all_path_contents(dwarf,
+                               _file_name_entry_format_count,
+                               _file_name_entry_format,
+                               _file_names_count,
+                               _file_names);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+
+} // namespace
 
 //--------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
We were getting reports of ORC failing to enumerate files properly, looking something like:

```
error: ODRV (structure:byte_size); 2 conflicts with `ZSTD_parameters`
    byte_size: 32 (0x20)
    symbol defintion location(s):
            <unsupported file index>:206 (used by `libzstd.a -> zstd_v04.c.o` and 0 others)

    byte_size: 40 (0x28)
    symbol defintion location(s):
            <unsupported file index>:1305 (used by `libzstd.a -> zdict.c.o` and 1 others)
```

This was due to extensive changes between DWARF4 and DWARF5 with respect to the line number program header, which is where file paths are stored. This update adds additional logic to the `line_header` reading code that accommodates the new structure.